### PR TITLE
Keep window/level settings in sync across viewers.

### DIFF
--- a/include/lib-viewer.h
+++ b/include/lib-viewer.h
@@ -186,6 +186,13 @@ typedef struct Viewer
   void (*on_focus_change_callback)(struct Viewer *viewer, void *data);
 
   /**
+   * A callback function to call on a "window/level change" event.
+   * @param viewer A pointer to the viewer object that triggered this callback.
+   * @param data   A pointer to a Range with the latest window/level values.
+   */
+  void (*on_window_level_change_callback)(struct Viewer *viewer, void *data);
+
+  /**
    * A callback function to call on a "handle change" event.
    * @param viewer A pointer to the viewer object that triggered this callback.
    * @param ratio  The ratio of DX / DY.
@@ -610,6 +617,17 @@ void viewer_replay_recording (Viewer *resources);
  */
 void viewer_replay_recording_over_time (Viewer *resources);
 
+
+/**
+ * A function to update the window width and window level of
+ * a Serie in a Viewer.
+ *
+ * @param resources   The viewer to set new window/level settings for.
+ * @param serie       The serie to apply the new window/level settings to.
+ * @param WWWL        The window width and window level values.
+ */
+void viewer_set_window_level_for_serie (Viewer *resources, Serie *serie,
+					Range WWWL);
 
 /**
  * @}

--- a/lib/lib-pixeldata/lib-pixeldata.c
+++ b/lib/lib-pixeldata/lib-pixeldata.c
@@ -333,7 +333,7 @@ pixeldata_apply_lookup_table (PixelData *pixeldata)
   {
     translated_value = (counter - minimum_voxel_value) * f_Slope;
 
-    display_lookup_table[counter] = (translated_value > array_items)
+    display_lookup_table[counter] = (translated_value >= array_items)
       ? color_lookup_table[array_items - 1]
       : color_lookup_table[translated_value];
   }

--- a/lib/lib-viewer/lib-viewer.c
+++ b/lib/lib-viewer/lib-viewer.c
@@ -1045,6 +1045,12 @@ viewer_on_mouse_move (UNUSED ClutterActor *actor, ClutterEvent *event, gpointer 
 
     // Trigger a full redraw.
     viewer_redraw (resources, REDRAW_ALL);
+
+    // Execute the window/level update callback.
+    if (resources->on_window_level_change_callback != NULL)
+    {
+      resources->on_window_level_change_callback (resources, &ts_NewWindowLevel);
+    }
   }
 
   resources->ts_CurrentMousePosition = ts_CurrentMousePosition;
@@ -1573,6 +1579,9 @@ viewer_set_callback (Viewer *resources, const char *name, void (*callback)(Viewe
   else if (!strcmp (name, "pixel-paint"))
     resources->on_pixel_paint_callback = callback;
 
+  else if (!strcmp (name, "window-level-change"))
+    resources->on_window_level_change_callback = callback;
+  
   else
   {
     debug_error ("Event '%s' is not implemented for Viewer.", name);
@@ -1713,6 +1722,25 @@ viewer_set_lookup_table_for_serie (Viewer *resources, Serie *serie, const char *
   pixeldata_set_color_lookup_table (pixeldata, lut_name);
   viewer_redraw (resources, REDRAW_ALL);
 }
+
+void viewer_set_window_level_for_serie (Viewer *resources, Serie *serie,
+					Range WWWL)
+{
+  debug_functions ();
+  assert (resources != NULL);
+  assert (serie != NULL);
+
+  PixelData *pixeldata = viewer_get_pixeldata_for_serie (resources, serie);
+  if (pixeldata == NULL)
+  {
+    debug_error ("Couldn't set the lookup table.");
+    return;
+  }
+
+  pixeldata_set_window_width_window_level (pixeldata, WWWL.minimum, WWWL.maximum);
+  viewer_redraw (resources, REDRAW_ALL);
+}
+
 
 
 PixelDataLookupTable*

--- a/source/gui/mainwindow.c
+++ b/source/gui/mainwindow.c
@@ -138,6 +138,7 @@ gboolean gui_mainwindow_terminal_toggle (GtkWidget *widget, void *data);
 gboolean gui_mainwindow_on_timeline_change (GtkWidget *widget, void *data);
 gboolean gui_mainwindow_overlay_add (GtkWidget *widget, void *data);
 void gui_mainwindow_set_active_layer (GtkListBox *box, GtkListBoxRow *row, void *user_data);
+void gui_mainwindow_update_viewer_wwwl (Viewer *viewer, void *data);
 
 gboolean gui_mainwindow_reset_viewport ();
 gboolean gui_mainwindow_toggle_follow_mode ();
@@ -904,6 +905,7 @@ gui_mainwindow_load_study (Tree *study_tree)
 
     viewer_set_callback (viewer, "pixel-paint", &gui_mainwindow_refresh_viewers);
     viewer_set_callback (viewer, "focus-change", &gui_mainwindow_update_viewer_positions);
+    viewer_set_callback (viewer, "window-level-change", &gui_mainwindow_update_viewer_wwwl);
     viewer_set_callback (viewer, "handle-change", &gui_mainwindow_update_handle_position);
 
     if (ts_ActiveDrawTool != NULL)
@@ -932,6 +934,7 @@ gui_mainwindow_load_study (Tree *study_tree)
 
     viewer_set_callback (viewer, "pixel-paint", &gui_mainwindow_refresh_viewers);
     viewer_set_callback (viewer, "focus-change", &gui_mainwindow_update_viewer_positions);
+    viewer_set_callback (viewer, "window-level-change", &gui_mainwindow_update_viewer_wwwl);
     viewer_set_callback (viewer, "handle-change", &gui_mainwindow_update_handle_position);
 
     if (ts_ActiveDrawTool != NULL)
@@ -960,6 +963,7 @@ gui_mainwindow_load_study (Tree *study_tree)
 
     viewer_set_callback (viewer, "pixel-paint", &gui_mainwindow_refresh_viewers);
     viewer_set_callback (viewer, "focus-change", &gui_mainwindow_update_viewer_positions);
+    viewer_set_callback (viewer, "window-level-change", &gui_mainwindow_update_viewer_wwwl);
     viewer_set_callback (viewer, "handle-change", &gui_mainwindow_update_handle_position);
 
     if (ts_ActiveDrawTool != NULL)
@@ -1292,6 +1296,31 @@ gui_mainwindow_update_viewer_positions (Viewer *viewer, void *data)
   }
 }
 
+
+void
+gui_mainwindow_update_viewer_wwwl (Viewer *viewer, void *data)
+{
+  debug_functions ();
+
+  ts_ActiveViewer = viewer;
+  if (data == NULL) return;
+
+  Serie *active_serie = CONFIGURATION_ACTIVE_LAYER (config);
+  if (active_serie == NULL) return;
+
+  Range wwwl = *(Range *)data;
+  List *temp = list_nth (pll_Viewers, 1);
+  while (temp != NULL)
+  {
+    Viewer* list_viewer = temp->data;
+
+    // Skip the Viewer that is calling back.
+    if (VIEWER_ORIENTATION (list_viewer) != VIEWER_ORIENTATION (viewer))
+      viewer_set_window_level_for_serie (list_viewer, active_serie, wwwl);
+
+    temp = temp->next;
+  }
+}
 
 
 /* Rotation vector around x-axis (http://en.wikipedia.org/wiki/Rotation_matrix)


### PR DESCRIPTION
- I added a new callback to Viewer to pass window/level changes to the graphical user interface.
- The graphical user interface calls for refreshing the lookup table on the other Viewers.
- When applying the color looup table, the program reads outside of the boundary of the LUT. A fix is included.
