### PR TITLE
Make GREL an optional part of clmedview

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -95,8 +95,10 @@ LIB_PIXELDATA_SOURCES	= lib/lib-pixeldata/lib-pixeldata.c \
 
 LIB_VIEWER_SOURCES	= lib/lib-viewer/lib-viewer.c
 
+if ENABLE_GREL
 LIB_GREL_SOURCES        = lib/lib-grel/lib-grel-shell.c \
                           lib/lib-grel/lib-grel-interpreter.c
+endif
 
 LIB_CONFIGURATION_SOURCES = lib/lib-configuration/lib-configuration.c
 
@@ -134,6 +136,10 @@ endif
 
 if ENABLE_MTRACE_OPTION
 AM_CFLAGS              += -DENABLE_MTRACE
+endif
+
+if ENABLE_GREL
+AM_CFLAGS              += -DENABLE_GREL
 endif
 
 clean-local: docs-clean plugins-clean

--- a/README
+++ b/README
@@ -23,7 +23,8 @@ tools installed:
 * Gtk+-3.0 and GLib-2.0
 * Clutter and Clutter-Gtk
 * zlib
-* Guile 2.0
+* (optional) Guile 2.0
+* (optional) VTE 2.91
 
 To build the documentation you need some more programs:
 * Texinfo

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ tools installed:
 * Gtk+-3.0 and GLib-2.0
 * Clutter and Clutter-Gtk
 * zlib
-* Guile 2.0
+* (optional) Guile 2.0
+* (optional) VTE 2.91
 
 To build the documentation you need some more programs:
 * Texinfo

--- a/configure.ac
+++ b/configure.ac
@@ -90,7 +90,19 @@ PKG_CHECK_MODULES([gtk], [gtk+-3.0])
 PKG_CHECK_MODULES([clutter], [clutter-1.0])
 PKG_CHECK_MODULES([cluttergtk], [clutter-gtk-1.0])
 PKG_CHECK_MODULES([zlib], [zlib])
-PKG_CHECK_MODULES([guile], [guile-2.0])
-PKG_CHECK_MODULES([vte], [vte-2.91])
+
+AC_SUBST(ENABLE_GREL)
+AC_ARG_WITH([grel],
+AS_HELP_STRING([--with-grel],
+[Build with GREL functionality.]))
+
+if test "x$with_grel" = "xyes"; then
+  PKG_CHECK_MODULES([guile], [guile-2.0])
+  PKG_CHECK_MODULES([vte], [vte-2.91])
+  AM_CONDITIONAL([ENABLE_GREL], [true])
+else
+  AM_CONDITIONAL([ENABLE_GREL], [false])
+fi
+
 
 AC_OUTPUT

--- a/lib/lib-grel/lib-grel-interpreter.c
+++ b/lib/lib-grel/lib-grel-interpreter.c
@@ -24,6 +24,7 @@
 
 #include <unistd.h>
 #include <stdlib.h>
+#include <string.h>
 #include <errno.h>
 #include <assert.h>
 

--- a/source/gui/mainwindow.c
+++ b/source/gui/mainwindow.c
@@ -564,7 +564,6 @@ gui_mainwindow_new (char *file)
   #ifdef ENABLE_GREL
   gtk_paned_pack2 (GTK_PANED (hbox_mainwindow), terminal_pane, TRUE, TRUE);
   #else
-  puts ("Packing without GREL.");
   gtk_paned_pack2 (GTK_PANED (hbox_mainwindow), vbox_mainarea, TRUE, TRUE);
   #endif
 

--- a/source/main.c
+++ b/source/main.c
@@ -27,9 +27,13 @@
 #endif
 
 #include "lib-configuration.h"
-#include "lib-grel-shell.h"
 #include "lib-memory.h"
 #include "gui/mainwindow.h"
+
+#ifdef ENABLE_GREL
+#include "lib-grel-shell.h"
+#endif
+
 
 // VERSION should be provided by the build system, otherwise define it here.
 #ifndef VERSION
@@ -40,9 +44,12 @@ static void
 show_help ()
 {
   puts ("\nAvailable options:\n"
-	" --file, -f      A valid path to a niftii file.\n"
-	" --version, -v   Show versioning information.\n"
-	" --help, -h      Show this message.\n");
+        " --file, -f          A valid path to a niftii file.\n"
+        #ifdef ENABLE_GREL
+        " --enable-grel, -g   Start a GREL shell.\n"
+        #endif
+        " --version, -v       Show versioning information.\n"
+        " --help, -h          Show this message.\n");
 }
 
 static void
@@ -112,7 +119,9 @@ main (int argc, char** argv)
   static struct option options[] =
   {
     { "file",              required_argument, 0, 'f' },
+    #ifdef ENABLE_GREL
     { "enable-grel",       no_argument,       0, 'g' },
+    #endif
     { "help",              no_argument,       0, 'h' },
     { "version",           no_argument,       0, 'v' },
     { 0,                   0,                 0, 0 }
@@ -127,12 +136,14 @@ main (int argc, char** argv)
     case 'f':
       file_path = optarg;
       break;
+    #ifdef ENABLE_GREL
     case 'g':
       {
 	grel_shell_start ();
 	start_gui = 0;
       }
       break;
+    #endif
     case 'v':
       printf ("Version: %s\n", VERSION);
       start_gui = 0;


### PR DESCRIPTION
Since GREL isn't very useful anyway, and it introduces two unusual dependencies to the project, it might be best to make it an optional feature.

This patch modifies the build system to not include GREL features by default. It won't check for libVTE or Guile when GREL is not enabled. The source code has been modified to reflect this change.

To enable GREL functionality, one must configure with the "--with-grel" option:
./configure --with-grel
