### PR TITLE
BUG: Window width and level aren't working properly.

### DIFF
--- a/include/lib-common.h
+++ b/include/lib-common.h
@@ -55,16 +55,6 @@ typedef struct
 typedef Coordinate3D Vector3D;
 
 /**
- * In the program there's a common need for storing a range defined
- * by a minimum and a maximum value.
- */
-typedef struct
-{
-  int minimum;
-  int maximum;
-} Range;
-
-/**
  * In the program there's a common need for storing width/height data.
  * This struct provides just that.
  */

--- a/include/lib-pixeldata.h
+++ b/include/lib-pixeldata.h
@@ -70,6 +70,17 @@ typedef struct
   unsigned int table_len; /*< The allocated number of bytes for 'table'. */
 } PixelDataLookupTable;
 
+/**
+ * In the program there's a common need for storing a range defined
+ * by a minimum and a maximum value.
+ */
+
+typedef struct
+{
+  int i32_windowWidth;
+  int i32_windowLevel;
+} WWWL;
+
 
 /**
  * This structure contains the values needed to generate RGB buffers
@@ -77,7 +88,7 @@ typedef struct
  */
 typedef struct
 {
-  Range WWWL; /*< Window width and window level values packed as a range. */
+  WWWL ts_WWWL;
 
   Slice *slice; /*< The current slice. */
   Serie *serie; /*< The Serie it belongs to. */
@@ -93,7 +104,7 @@ typedef struct
 
   PixelDataLookupTable *color_lookup_table_ptr; /*< A pointer to the active
 						    color lookup table. */
-  
+
 } PixelData;
 
 
@@ -212,7 +223,7 @@ PixelDataLookupTable* pixeldata_lookup_table_get_default_overlay ();
  * your newly selected lookup table is not used (yet). This function is used
  * by pixeldata_set_color_lookup_table(), so you probably don't have to call it
  * yourself.
- * 
+ *
  * @param pixeldata  A pointer to the PixelData to apply the LUT of.
  */
 void pixeldata_apply_lookup_table (PixelData *pixeldata);
@@ -223,10 +234,7 @@ void pixeldata_apply_lookup_table (PixelData *pixeldata);
  *
  * @return 1 on success, 0 on failure.
  */
-short pixeldata_set_window_width_window_level (PixelData *pixeldata,
-                                               int minimum,
-                                               int maximum);
-
+short pixeldata_calculate_window_width_level (PixelData *pixeldata, int i32_deltaWidth, int i32_deltaLevel);
 
 /**
  * This function creates an RGB buffer for a given PixelData. This function
@@ -241,7 +249,7 @@ unsigned int* pixeldata_create_rgb_pixbuf (PixelData *data);
 
 
 /**
- * This function destroys an RGB buffer created by 
+ * This function destroys an RGB buffer created by
  * pixeldata_create_rgb_pixbuf().
  *
  * @param pixbuf  The pixbuf returned by pixeldata_create_rgb_pixbuf().
@@ -276,18 +284,19 @@ short int pixeldata_set_slice (PixelData *pixeldata, Slice *slice);
  * one call. It calls other functions in the library to set everything up.
  *
  * @param lut              The look-up table to use.
- * @param i32_MinPixValue  The window-level minimum value.
- * @param i32_MaxPixValue  The window-level maximum value.
- * @param slice            A pointer to a Slice.
+ * @param i32_windowWidth  The window-width parameter.
+ * @param i32_windowLevel  The window-level parameter.
+ * @param slice            A pointer to a slice.
  * @param serie            The serie to create pixeldata for.
  *
  * @return A pointer to allocated PixelData on succes or NULL on failure.
  */
-PixelData * pixeldata_new_with_lookup_table (PixelDataLookupTable *lut,
-                                             int i32_MinPixValue,
-                                             int i32_MaxPixValue,
-                                             Slice *slice,
-                                             Serie *serie);
+PixelData*
+pixeldata_new_with_lookup_table (PixelDataLookupTable *lut,
+                                 int i32_windowWidth,
+                                 int i32_windowLevel,
+                                 Slice *slice,
+                                 Serie *serie);
 
 
 /**
@@ -372,8 +381,8 @@ short int pixeldata_set_voxel (PixelData *mask, PixelData *selection,
  *
  * @param mask    The mask to use for drawing.
  * @param point   The coordinate to get the pixel value for.
- * @param value   A pointer to the value of the pixel. The type of the value 
- *                depends on the image type. 
+ * @param value   A pointer to the value of the pixel. The type of the value
+ *                depends on the image type.
  *
  * @return 1 when the request is valid, 0 when the request is invalid.
  */

--- a/include/lib-viewer.h
+++ b/include/lib-viewer.h
@@ -166,7 +166,7 @@ typedef struct Viewer
 
   List *pll_Replay; /*< A list of replayable actions. */
   short int is_recording; /*< A state variable for recording. */
-  
+
   /*--------------------------------------------------------------------------.
    | SIGNALS                                                                  |
    '--------------------------------------------------------------------------*/
@@ -272,7 +272,7 @@ typedef struct Viewer
  * @param ts_PivotPoint      The position vector.
  * @param ts_UpVector        The vector to determine the rotate base position.
  *
- * @return A pointer to a Viewer. Use the VIEWER_WIDGET macro to get a 
+ * @return A pointer to a Viewer. Use the VIEWER_WIDGET macro to get a
  *         GtkWidget that can be displayed.
  */
 Viewer* viewer_new (Serie *ts_Original, Serie *ts_Mask, List *pll_Overlays,
@@ -624,10 +624,10 @@ void viewer_replay_recording_over_time (Viewer *resources);
  *
  * @param resources   The viewer to set new window/level settings for.
  * @param serie       The serie to apply the new window/level settings to.
- * @param WWWL        The window width and window level values.
+ * @param i32_windowWidth  The window width value.
+ * @param i32_windowLevel  The window level value.
  */
-void viewer_set_window_level_for_serie (Viewer *resources, Serie *serie,
-					Range WWWL);
+void viewer_set_window_level_for_serie (Viewer *resources, Serie *serie, int i32_windowWidth, int i32_windowLevel);
 
 /**
  * @}

--- a/source/gui/mainwindow.c
+++ b/source/gui/mainwindow.c
@@ -432,7 +432,7 @@ gui_mainwindow_new (char *file)
   #ifdef ENABLE_GREL
   gtk_header_bar_pack_start (GTK_HEADER_BAR (header), btn_terminal_toggle);
   #endif
-  
+
   // Disable the 'Save' button by default.
   gtk_widget_set_sensitive (btn_file_save, FALSE);
   gtk_widget_set_sensitive (btn_reset_viewport, FALSE);
@@ -1249,7 +1249,7 @@ gui_mainwindow_update_viewer_wwwl (Viewer *viewer, void *data)
   Serie *active_serie = CONFIGURATION_ACTIVE_LAYER (config);
   if (active_serie == NULL) return;
 
-  Range wwwl = *(Range *)data;
+  WWWL wwwl = *(WWWL *)data;
   List *temp = list_nth (pll_Viewers, 1);
   while (temp != NULL)
   {
@@ -1257,10 +1257,11 @@ gui_mainwindow_update_viewer_wwwl (Viewer *viewer, void *data)
 
     // Skip the Viewer that is calling back.
     if (VIEWER_ORIENTATION (list_viewer) != VIEWER_ORIENTATION (viewer))
-      viewer_set_window_level_for_serie (list_viewer, active_serie, wwwl);
+      viewer_set_window_level_for_serie (list_viewer, active_serie, wwwl.i32_windowWidth, wwwl.i32_windowLevel);
 
     temp = temp->next;
   }
+
 }
 
 
@@ -1450,7 +1451,7 @@ gui_mainwindow_on_key_press (UNUSED GtkWidget *widget, GdkEventKey *event,
       && !(event->state & GDK_CONTROL_MASK))
     return FALSE;
   #endif
-  
+
   /*--------------------------------------------------------------------------.
    | KEY RESPONSES                                                            |
    '--------------------------------------------------------------------------*/


### PR DESCRIPTION
Window width and level aren't working properly.
The minimum and maximum calculation to determine a window width and level is performed
(completely) wrong. This results in a range which is always 0-255.

FIX:
The functionality is rewritten. This causes several changes. Gui related operations are now
stored in lib-viewer, pixel related operation are stored in lib-pixeldata.

The fix causes the changes in:
include/lib-common.h
- Removed Range struct

include/lib-pixeldata.h
- Added WWWL struct
- Added WWWL in pixeldata struct
- Added function pixeldata_calculate_window_width_level
- Removed function pixeldata_set_window_width_window_level

include/lib-viewer.h
- Changed interface function viewer_set_window_level_for_serie

lib/lib-pixeldata/lib-pixeldata.c
- Removed all code refering to WWWL.-*-imum
- Added window width and window level functionality

lib/lib-viewer/lib-viewer.c
- Removed all code refering to WWWL.-*-imum
- Added window width and window level functionality
