### PR TITLE
BUG: After scroll, mask data isn't synced

### DIFF
--- a/lib/lib-viewer/lib-viewer.c
+++ b/lib/lib-viewer/lib-viewer.c
@@ -363,6 +363,8 @@ viewer_on_mouse_scroll_prevnext (UNUSED ClutterActor *actor, ClutterEvent *event
     default: break;
   }
 
+  f_Z = PIXELDATA_ACTIVE_SLICE (resources->ps_Original)->matrix.z;
+
   viewer_update_slices (resources->pll_MaskSeries, f_Z);
   viewer_update_slices (resources->pll_OverlaySeries, f_Z);
 


### PR DESCRIPTION
BUG: After scroll, mask and overlay data isn't synced.

FIX: Add f_z extraction after CLUTTER_SCROLL_SMOOTH handle.
