### PR TITLE
Feature Change: Path of file when saving a mask.

### DIFF
--- a/include/lib-memory-serie.h
+++ b/include/lib-memory-serie.h
@@ -64,6 +64,12 @@ typedef struct
   char name[100];
 
   /**
+   * The filename of Serie.
+   */
+  char *pc_filename;
+
+
+  /**
    * The group identifier to which this Serie belongs.
    */
   unsigned long long group_id;
@@ -221,10 +227,12 @@ unsigned long long memory_serie_next_id ();
  * This function returns a newly created Serie object.
  *
  * @param name  A name for the serie.
+ * @param fileName  The filename of the original file.
  *
  * @return A pointer to a newly created Serie object.
  */
-Serie* memory_serie_new (const char *name);
+Serie*
+memory_serie_new (const char *name, const char *pc_filename);
 
 
 /**

--- a/lib/lib-memory/lib-memory-io.c
+++ b/lib/lib-memory/lib-memory-io.c
@@ -35,6 +35,7 @@
 #define PATH_SEPARATOR '/'
 #endif
 
+
 /*                                                                                                    */
 /*                                                                                                    */
 /* LOCAL FUNCTIONS                                                                                    */
@@ -79,8 +80,8 @@ memory_io_load_file (Tree **patient_tree, const char *path)
         Tree *study_tree = tree_append_child (*patient_tree, study, TREE_TYPE_STUDY);
 
         serie = (filename[0] == PATH_SEPARATOR)
-          ? memory_serie_new (filename + 1)
-          : memory_serie_new (filename);
+          ? memory_serie_new (filename + 1, path )
+          : memory_serie_new (filename, path );
 
         tree_append_child (study_tree, serie, TREE_TYPE_SERIE);
 
@@ -123,7 +124,7 @@ memory_io_load_file (Tree **patient_tree, const char *path)
         Study *study = memory_study_new (filename);
         Tree *study_tree = tree_append_child (*patient_tree, study, TREE_TYPE_STUDY);
 
-        Serie *serie = memory_serie_new (filename);
+        Serie *serie = memory_serie_new (filename,filename);
         tree_append_child (study_tree, serie, TREE_TYPE_SERIE);
 
         if (!memory_io_niftii_load (serie, &c_HeaderFile[0], &c_ImageFile[0])) return 0;

--- a/source/gui/mainwindow.c
+++ b/source/gui/mainwindow.c
@@ -712,6 +712,8 @@ gui_mainwindow_menu_file_activate (UNUSED GtkWidget *widget, void *data)
   {
     case GUI_FILE_OPEN:
       gui_mainwindow_file_load (NULL);
+
+
       break;
     case GUI_FILE_SAVE_MASK:
       gui_mainwindow_file_export ();
@@ -810,6 +812,7 @@ gui_mainwindow_file_load (void* data)
 
     Tree *root_tree = tree_nth (CONFIGURATION_MEMORY_TREE (config), 1);
     if (!memory_io_load_file (&root_tree, filename)) return;
+
 
 
     CONFIGURATION_MEMORY_TREE (config) = root_tree;
@@ -1099,11 +1102,7 @@ gui_mainwindow_file_export ()
       continue;
     }
 
-    char serie_name[100];
-    memset (serie_name, 0, 100);
-    strcpy (serie_name, serie->name);
-
-    memory_io_save_file (serie, serie_name);
+    memory_io_save_file (serie, serie->pc_filename);
     pll_Series = tree_next (pll_Series);
   }
 
@@ -1877,7 +1876,7 @@ gui_mainwindow_overlay_add (UNUSED GtkWidget *widget, void *data)
 
   if (filename != NULL)
   {
-    Serie *serie = memory_serie_new (filename);
+    Serie *serie = memory_serie_new (filename, filename);
     if (!memory_io_niftii_load (serie, filename, NULL)) return FALSE;
 
     tree_append_child (CONFIGURATION_ACTIVE_STUDY (config), serie, TREE_TYPE_SERIE_OVERLAY);


### PR DESCRIPTION
Feature Change:
When you hit the save button, all masks are stored on disk. Currently the mask is stored in the execution path of the application (clmedview is
in /home/stuupke/clmedview, so the masks are stored in /home/stuupke/x_clone_x.nii)

Changes:
Files are now stored in the directory of the original image. The _clone_ is replaced with _mask_. The masks are numbered with preceding zero's.
The file path is stored in the serie struct at creation of the struct. If the file exisist, the file will be regardless overwritten.

include/lib-memory-serie.h
- Changed funcion declareation memory_serie_new()

lib/lib-memory/lib-memory-io.c
source/gui/mainwindow.c
- Changed function arguments

include/lib-memory-serie.c
- Added some code to achive the desired functionality memory_serie_new()
