### PR TITLE
BUGS: Images aren't displayed correct. 

### DIFF
--- a/include/lib-common.h
+++ b/include/lib-common.h
@@ -55,6 +55,20 @@ typedef struct
 typedef Coordinate3D Vector3D;
 
 /**
+ * In the program there's a common need for storing x/y/z as short int data.
+ * This struct provides just that.
+ */
+typedef struct
+{
+  short int i16_x;
+  short int i16_y;
+  short int i16_z;
+} ts_Coordinate3DInt;
+
+typedef ts_Coordinate3DInt ts_Vector3DInt;
+
+
+/**
  * In the program there's a common need for storing width/height data.
  * This struct provides just that.
  */

--- a/include/lib-io-dicom.h
+++ b/include/lib-io-dicom.h
@@ -92,14 +92,4 @@ short int i16_memory_io_dicom_loadSingleSlice(Serie *ps_serie,
                                               short int i16_SliceNumber,
                                               short int i16_timeFrameNumber);
 
-/**
- * Load a dicom file from disk to the selected memory.
- *
- * @param serie    The selected memory to store all needed parameters in
- * @param pc_file Filename/path of the header file
- *
- * @return 0 or FALSE if function executes wrong, 1 or TRUE if execution is correct
- */
-short int i16_memory_io_dicom_load(Patient  *ps_patient, Study *ps_study, Serie *ps_serie, const char *pc_dicom);
-
 #endif//NIFTII_NIFTII_H

--- a/include/lib-memory-serie.h
+++ b/include/lib-memory-serie.h
@@ -104,7 +104,7 @@ typedef struct
   /**
    * The 3D size matrix of the Serie volume.
    */
-  Coordinate3D matrix;
+  ts_Coordinate3DInt matrix;
 
   /**
    * The pixel dimension matrix of the Serie.
@@ -170,11 +170,6 @@ typedef struct
   */
   double d_Qfac;
 
-  /**
-  * A value which indicates the stride in a positive direction according to
-  * the right handed coordinate system
-  */
-  Vector3D ts_Stride;
 
   /**
   * Quaternion code code which defined the type of space

--- a/include/lib-memory-slice.h
+++ b/include/lib-memory-slice.h
@@ -51,11 +51,14 @@ extern "C" {
  */
 typedef struct
 {
+  Vector3D ts_normalVector;
   Vector3D ts_perpendicularVector;
   Vector3D ts_crossproductVector;
 
-  int i32_StrideHeight;
-  int i32_StrideWidth;
+
+  short int i16_StrideHeight;
+  short int i16_StrideWidth;
+  short int i16_StrideDepth;
 
   short int i16_StartHeight;
   short int i16_StartWidth;
@@ -77,7 +80,7 @@ typedef struct
   /**
    * The size matrix of the Slice.
    */
-  Coordinate3D matrix;
+  ts_Coordinate3DInt matrix;
 
   /**
    * The point in time for time series.

--- a/lib/lib-io-nifti/nifti1_io.c
+++ b/lib/lib-io-nifti/nifti1_io.c
@@ -28,7 +28,7 @@
  */
 
 /*! global history and version strings, for printing */
-static char * gni_history[] = 
+static char * gni_history[] =
 {
   "----------------------------------------------------------------------\n"
   "history (of nifti library changes):\n"
@@ -336,7 +336,7 @@ static char * gni_history[] =
 static char gni_version[] = "nifti library version 1.41 (28 April, 2010)";
 
 /*! global nifti options structure - init with defaults */
-static nifti_global_options g_opts = { 
+static nifti_global_options g_opts = {
         1, /* debug level                                         */
         0, /* skip_blank_ext    - skip extender if no extensions  */
         1  /* allow_upper_fext  - allow uppercase file extensions */
@@ -345,8 +345,8 @@ static nifti_global_options g_opts = {
 /*! global nifti types structure list (per type, ordered oldest to newest) */
 static nifti_type_ele nifti_type_list[] = {
     /* type  nbyper  swapsize   name  */
-    {    0,     0,       0,   "DT_UNKNOWN"              }, 
-    {    0,     0,       0,   "DT_NONE"                 }, 
+    {    0,     0,       0,   "DT_UNKNOWN"              },
+    {    0,     0,       0,   "DT_NONE"                 },
     {    1,     0,       0,   "DT_BINARY"               },  /* not usable */
     {    2,     1,       0,   "DT_UNSIGNED_CHAR"        },
     {    2,     1,       0,   "DT_UINT8"                },
@@ -464,7 +464,7 @@ void nifti_disp_lib_version( void )
 /*! nifti_image_read_bricks        - read nifti data as array of bricks
  *
  *                                   13 Dec 2004 [rickr]
- * 
+ *
  *  \param  hname    - filename of dataset to read (must be valid)
  *  \param  nbricks  - number of sub-bricks to read
  *                     (if blist is valid, nbricks must be > 0)
@@ -703,7 +703,7 @@ int nifti_update_dims_from_array( nifti_image * nim )
  * \param    NBL      - pointer to struct where resulting data will be stored
  *
  * If blist is NULL, read all sub-bricks.
- * 
+ *
  * \return the number of loaded bricks (NBL->nbricks),
  *    0 on failure, < 0 on error
  *
@@ -933,7 +933,7 @@ static int nifti_alloc_NBL_mem(nifti_image * nim, int nbricks,
  * 2. create an sindex list, and init with 0..nbricks-1
  * 3. do a slow insertion sort on the small slist, along with sindex list
  * 4. check results, just to be positive
- * 
+ *
  * So slist is sorted, and sindex hold original positions.
  *
  * return 0 on success, -1 on failure
@@ -1417,7 +1417,7 @@ void nifti_datatype_sizes( int datatype , int *nbyper, int *swapsize )
 }
 
 /*---------------------------------------------------------------------------*/
-/*! Given the quaternion parameters (etc.), compute a transformation matrix.
+/*! Given the quaternion parameters (etc.), compute a transformation matrix
 
    See comments in nifti1.h for details.
      - qb,qc,qd = quaternion parameters
@@ -2103,7 +2103,7 @@ void nifti_mat44_to_orientation( mat44 R , int *icod, int *jcod, int *kcod )
 
 /*----------------------------------------------------------------------*/
 /*! swap each byte pair from the given list of n pairs
- * 
+ *
  *  Due to alignment of structures at some architectures (e.g. on ARM),
  *  stick to char varaibles.
  *  Fixes http://bugs.debian.org/446893   Yaroslav <debian@onerussian.com>
@@ -2321,7 +2321,7 @@ int nifti_swap_as_analyze( nifti_analyze75 * h )
 
 /*-------------------------------------------------------------------------*/
 /*! OLD VERSION of swap_nifti_header (left for undo/compare operations)
-  
+
     Byte swap NIFTI-1 file header in various places and ways.
 
     If is_nifti is nonzero, will also swap the NIFTI-specific
@@ -2434,7 +2434,7 @@ int nifti_fileexists(const char* fname)
 
 /*----------------------------------------------------------------------*/
 /*! return whether the filename is valid
- 
+
     Note: uppercase extensions are now valid.    27 Apr 2009 [rickr]
 
     The name is considered valid if the file basename has length greater than
@@ -2477,7 +2477,7 @@ int nifti_is_complete_filename(const char* fname)
 
 /*----------------------------------------------------------------------*/
 /*! return whether the filename is valid
- 
+
     Allow uppercase extensions as valid.        27 Apr 2009 [rickr]
     Any .gz extension case must match the base extension case.
 
@@ -2631,7 +2631,7 @@ char * nifti_makebasename(const char* fname)
 
    ext = nifti_find_file_extension(basename);
    if ( ext ) *ext = '\0';  /* clear out extension */
-   
+
    return basename;  /* in either case */
 }
 
@@ -2671,7 +2671,7 @@ void nifti_set_allow_upper_fext( int allow )
 /*! check current directory for existing header file
 
     \return filename of header on success and NULL if no appropriate file
-            could be found 
+            could be found
 
     If fname has an uppercase extension, check for uppercase files.
 
@@ -2697,14 +2697,14 @@ char * nifti_findhdrname(const char* fname)
    ext = nifti_find_file_extension(fname);
 
    if( ext ) eisupper = is_uppercase(ext);  /* do we look for uppercase? */
-   
+
    /* if the file exists and is a valid header name (not .img), return it */
-   if ( ext && nifti_fileexists(fname) ) { 
+   if ( ext && nifti_fileexists(fname) ) {
      /* allow for uppercase extension */
      if ( fileext_n_compare(ext,".img",4) != 0 ){
-        hdrname = strdup(fname); 
+        hdrname = strdup(fname);
         free(basename);
-        return hdrname; 
+        return hdrname;
      } else
         efirst = 0;     /* note for below */
    }
@@ -2737,7 +2737,7 @@ char * nifti_findhdrname(const char* fname)
    strcat(hdrname,elist[efirst]);
    if (nifti_fileexists(hdrname)) { free(basename); return hdrname; }
 #ifdef HAVE_ZLIB
-   strcat(hdrname,extzip); 
+   strcat(hdrname,extzip);
    if (nifti_fileexists(hdrname)) { free(basename); return hdrname; }
 #endif
 
@@ -2749,13 +2749,13 @@ char * nifti_findhdrname(const char* fname)
    strcat(hdrname,elist[efirst]);
    if (nifti_fileexists(hdrname)) { free(basename); return hdrname; }
 #ifdef HAVE_ZLIB
-   strcat(hdrname,extzip); 
+   strcat(hdrname,extzip);
    if (nifti_fileexists(hdrname)) { free(basename); return hdrname; }
 #endif
 
    /**- if nothing has been found, return NULL */
-   free(basename); 
-   free(hdrname); 
+   free(basename);
+   free(hdrname);
    return NULL;
 }
 
@@ -2856,7 +2856,7 @@ char * nifti_findimgname(const char* fname , int nifti_type)
    \param   comp        - add .gz for compressed name
 
    Note that if prefix provides a file suffix, nifti_type is not used.
-  
+
    NB: this allocates memory which should be freed
 
    \sa nifti_set_filenames
@@ -2912,7 +2912,7 @@ char * nifti_makehdrname(const char * prefix, int nifti_type, int check,
 
    return iname;
 }
-   
+
 
 /*----------------------------------------------------------------------*/
 /*! creates a filename for storing the image, based on nifti_type
@@ -2921,9 +2921,9 @@ char * nifti_makehdrname(const char * prefix, int nifti_type, int check,
    \param   nifti_type  - determines the extension, unless provided by prefix
    \param   check       - check for existence (fail condition)
    \param   comp        - add .gz for compressed name
-  
+
    Note that if prefix provides a file suffix, nifti_type is not used.
-  
+
    NB: it allocates memory which should be freed
 
    \sa nifti_set_filenames
@@ -2992,7 +2992,7 @@ char * nifti_makeimgname(const char * prefix, int nifti_type, int check,
                          (this is probably a logical place to do so)
 
    \return 0 on successful update
- 
+
    \warning this will free() any existing names and create new ones
 
    \sa nifti_makeimgname, nifti_makehdrname, nifti_type_and_names_match
@@ -3539,7 +3539,7 @@ int disp_nifti_1_header( const char * info, const nifti_1_header * hp )
 
 /*----------------------------------------------------------------------*/
 /*! convert a nifti_1_header into a nift1_image
-  
+
    \return an allocated nifti_image, or NULL on failure
 *//*--------------------------------------------------------------------*/
 nifti_image* nifti_convert_nhdr2nim(struct nifti_1_header nhdr,
@@ -3558,7 +3558,7 @@ nifti_image* nifti_convert_nhdr2nim(struct nifti_1_header nhdr,
    nim->data = NULL;
 
    /**- check if we must swap bytes */
-  
+
    doswap = need_nhdr_swap(nhdr.dim[0], nhdr.sizeof_hdr); /* swap data flag */
 
    if( doswap < 0 ){
@@ -3623,14 +3623,14 @@ nifti_image* nifti_convert_nhdr2nim(struct nifti_1_header nhdr,
   if( is_nifti ) nim->nifti_type = (is_onefile) ? NIFTI_FTYPE_NIFTI1_1
                                                 : NIFTI_FTYPE_NIFTI1_2 ;
   else           nim->nifti_type = NIFTI_FTYPE_ANALYZE ;
-  
+
   ii = nifti_short_order() ;
   if( doswap )   nim->byteorder = REVERSE_ORDER(ii) ;
   else           nim->byteorder = ii ;
-  
+
 
   /**- set dimensions of data array */
-  
+
   nim->ndim = nim->dim[0] = nhdr.dim[0];
   nim->nx   = nim->dim[1] = nhdr.dim[1];
   nim->ny   = nim->dim[2] = nhdr.dim[2];
@@ -3642,16 +3642,16 @@ nifti_image* nifti_convert_nhdr2nim(struct nifti_1_header nhdr,
 
   for( ii=1, nim->nvox=1; ii <= nhdr.dim[0]; ii++ )
      nim->nvox *= nhdr.dim[ii];
-  
+
   /**- set the type of data in voxels and how many bytes per voxel */
-  
+
   nim->datatype = nhdr.datatype ;
-  
+
   nifti_datatype_sizes( nim->datatype , &(nim->nbyper) , &(nim->swapsize) ) ;
   if( nim->nbyper == 0 ){ free(nim); ERREX("bad datatype"); }
-  
+
   /**- set the grid spacings */
-  
+
   nim->dx = nim->pixdim[1] = nhdr.pixdim[1] ;
   nim->dy = nim->pixdim[2] = nhdr.pixdim[2] ;
   nim->dz = nim->pixdim[3] = nhdr.pixdim[3] ;
@@ -3659,43 +3659,43 @@ nifti_image* nifti_convert_nhdr2nim(struct nifti_1_header nhdr,
   nim->du = nim->pixdim[5] = nhdr.pixdim[5] ;
   nim->dv = nim->pixdim[6] = nhdr.pixdim[6] ;
   nim->dw = nim->pixdim[7] = nhdr.pixdim[7] ;
-  
+
   /**- compute qto_xyz transformation from pixel indexes (i,j,k) to (x,y,z) */
-  
+
   if( !is_nifti || nhdr.qform_code <= 0 ){
     /**- if not nifti or qform_code <= 0, use grid spacing for qto_xyz */
-    
+
     nim->qto_xyz.m[0][0] = nim->dx ;  /* grid spacings */
     nim->qto_xyz.m[1][1] = nim->dy ;  /* along diagonal */
     nim->qto_xyz.m[2][2] = nim->dz ;
-    
+
     /* off diagonal is zero */
-    
+
     nim->qto_xyz.m[0][1]=nim->qto_xyz.m[0][2]=nim->qto_xyz.m[0][3] = 0.0;
     nim->qto_xyz.m[1][0]=nim->qto_xyz.m[1][2]=nim->qto_xyz.m[1][3] = 0.0;
     nim->qto_xyz.m[2][0]=nim->qto_xyz.m[2][1]=nim->qto_xyz.m[2][3] = 0.0;
-    
+
     /* last row is always [ 0 0 0 1 ] */
-    
+
     nim->qto_xyz.m[3][0]=nim->qto_xyz.m[3][1]=nim->qto_xyz.m[3][2] = 0.0;
     nim->qto_xyz.m[3][3]= 1.0 ;
-    
+
     nim->qform_code = NIFTI_XFORM_UNKNOWN ;
-    
+
     if( g_opts.debug > 1 ) fprintf(stderr,"-d no qform provided\n");
   } else {
     /**- else NIFTI: use the quaternion-specified transformation */
-    
+
     nim->quatern_b = FIXED_FLOAT( nhdr.quatern_b ) ;
     nim->quatern_c = FIXED_FLOAT( nhdr.quatern_c ) ;
     nim->quatern_d = FIXED_FLOAT( nhdr.quatern_d ) ;
-    
+
     nim->qoffset_x = FIXED_FLOAT(nhdr.qoffset_x) ;
     nim->qoffset_y = FIXED_FLOAT(nhdr.qoffset_y) ;
     nim->qoffset_z = FIXED_FLOAT(nhdr.qoffset_z) ;
-    
+
     nim->qfac = (nhdr.pixdim[0] < 0.0) ? -1.0 : 1.0 ;  /* left-handedness? */
-    
+
     nim->qto_xyz = nifti_quatern_to_mat44(
                       nim->quatern_b, nim->quatern_c, nim->quatern_d,
                       nim->qoffset_x, nim->qoffset_y, nim->qoffset_z,
@@ -3707,88 +3707,88 @@ nifti_image* nifti_convert_nhdr2nim(struct nifti_1_header nhdr,
     if( g_opts.debug > 1 )
        nifti_disp_matrix_orient("-d qform orientations:\n", nim->qto_xyz);
   }
-  
+
   /**- load inverse transformation (x,y,z) -> (i,j,k) */
-  
+
   nim->qto_ijk = nifti_mat44_inverse( nim->qto_xyz ) ;
-  
+
   /**- load sto_xyz affine transformation, if present */
-  
+
   if( !is_nifti || nhdr.sform_code <= 0 ){
     /**- if not nifti or sform_code <= 0, then no sto transformation */
-    
+
     nim->sform_code = NIFTI_XFORM_UNKNOWN ;
 
     if( g_opts.debug > 1 ) fprintf(stderr,"-d no sform provided\n");
-    
+
   } else {
     /**- else set the sto transformation from srow_*[] */
-    
+
     nim->sto_xyz.m[0][0] = nhdr.srow_x[0] ;
     nim->sto_xyz.m[0][1] = nhdr.srow_x[1] ;
     nim->sto_xyz.m[0][2] = nhdr.srow_x[2] ;
     nim->sto_xyz.m[0][3] = nhdr.srow_x[3] ;
-    
+
     nim->sto_xyz.m[1][0] = nhdr.srow_y[0] ;
     nim->sto_xyz.m[1][1] = nhdr.srow_y[1] ;
     nim->sto_xyz.m[1][2] = nhdr.srow_y[2] ;
     nim->sto_xyz.m[1][3] = nhdr.srow_y[3] ;
-    
+
     nim->sto_xyz.m[2][0] = nhdr.srow_z[0] ;
     nim->sto_xyz.m[2][1] = nhdr.srow_z[1] ;
     nim->sto_xyz.m[2][2] = nhdr.srow_z[2] ;
     nim->sto_xyz.m[2][3] = nhdr.srow_z[3] ;
-    
+
     /* last row is always [ 0 0 0 1 ] */
-    
+
     nim->sto_xyz.m[3][0]=nim->sto_xyz.m[3][1]=nim->sto_xyz.m[3][2] = 0.0;
     nim->sto_xyz.m[3][3]= 1.0 ;
-    
+
     nim->sto_ijk = nifti_mat44_inverse( nim->sto_xyz ) ;
-    
+
     nim->sform_code = nhdr.sform_code ;
 
     if( g_opts.debug > 1 )
        nifti_disp_matrix_orient("-d sform orientations:\n", nim->sto_xyz);
   }
-  
+
   /**- set miscellaneous NIFTI stuff */
-  
+
   if( is_nifti ){
     nim->scl_slope   = FIXED_FLOAT( nhdr.scl_slope ) ;
     nim->scl_inter   = FIXED_FLOAT( nhdr.scl_inter ) ;
-    
+
     nim->intent_code = nhdr.intent_code ;
-    
+
     nim->intent_p1 = FIXED_FLOAT( nhdr.intent_p1 ) ;
     nim->intent_p2 = FIXED_FLOAT( nhdr.intent_p2 ) ;
     nim->intent_p3 = FIXED_FLOAT( nhdr.intent_p3 ) ;
-    
+
     nim->toffset   = FIXED_FLOAT( nhdr.toffset ) ;
-    
+
     memcpy(nim->intent_name,nhdr.intent_name,15); nim->intent_name[15] = '\0';
-    
+
     nim->xyz_units  = XYZT_TO_SPACE(nhdr.xyzt_units) ;
     nim->time_units = XYZT_TO_TIME (nhdr.xyzt_units) ;
-    
+
     nim->freq_dim  = DIM_INFO_TO_FREQ_DIM ( nhdr.dim_info ) ;
     nim->phase_dim = DIM_INFO_TO_PHASE_DIM( nhdr.dim_info ) ;
     nim->slice_dim = DIM_INFO_TO_SLICE_DIM( nhdr.dim_info ) ;
-    
+
     nim->slice_code     = nhdr.slice_code  ;
     nim->slice_start    = nhdr.slice_start ;
     nim->slice_end      = nhdr.slice_end   ;
     nim->slice_duration = FIXED_FLOAT(nhdr.slice_duration) ;
   }
-  
+
   /**- set Miscellaneous ANALYZE stuff */
-  
+
   nim->cal_min = FIXED_FLOAT(nhdr.cal_min) ;
   nim->cal_max = FIXED_FLOAT(nhdr.cal_max) ;
-  
+
   memcpy(nim->descrip ,nhdr.descrip ,79) ; nim->descrip [79] = '\0' ;
   memcpy(nim->aux_file,nhdr.aux_file,23) ; nim->aux_file[23] = '\0' ;
-  
+
    /**- set ioff from vox_offset (but at least sizeof(header)) */
 
    is_onefile = is_nifti && NIFTI_ONEFILE(nhdr) ;
@@ -3806,9 +3806,9 @@ nifti_image* nifti_convert_nhdr2nim(struct nifti_1_header nhdr,
    if (fname!=NULL) {
        nifti_set_filenames(nim,fname,0,0);
        if (nim->iname==NULL)  { ERREX("bad filename"); }
-   } else { 
-     nim->fname = NULL;  
-     nim->iname = NULL; 
+   } else {
+     nim->fname = NULL;
+     nim->iname = NULL;
    }
 
    /* clear extension fields */
@@ -3856,11 +3856,11 @@ znzFile nifti_image_open(const char * hname, char * opts, nifti_image ** nim)
   if( ((*nim) == NULL)      || ((*nim)->iname == NULL) ||
       ((*nim)->nbyper <= 0) || ((*nim)->nvox <= 0)       )
      ERREX("bad header info") ;
-                                                                                
+
   /* open image data file */
   fptr = znzopen( (*nim)->iname, opts, nifti_is_gzfile((*nim)->iname) );
   if( znz_isnull(fptr) ) ERREX("Can't open data file") ;
-                                                                                
+
   return fptr;
 }
 
@@ -3887,7 +3887,7 @@ nifti_1_header * nifti_read_header(const char * hname, int * swapped, int check)
    int              bytes, lswap;
    char           * hfile;
    char             fname[] = { "nifti_read_header" };
-   
+
    /* determine file name to use for header */
    hfile = nifti_findhdrname(hname);
    if( hfile == NULL ){
@@ -3913,7 +3913,7 @@ nifti_1_header * nifti_read_header(const char * hname, int * swapped, int check)
       return NULL;
    }
 
-   /* read the binary header */ 
+   /* read the binary header */
    bytes = (int)znzread( &nhdr, 1, sizeof(nhdr), fp );
    znzclose( fp );                      /* we are done with the file now */
 
@@ -4026,7 +4026,7 @@ int nifti_hdr_looks_good(const nifti_1_header * hdr)
 
 /*----------------------------------------------------------------------
  * check whether byte swapping is needed
- * 
+ *
  * dim[0] should be in [0,7], and sizeof_hdr should be accurate
  *
  * \returns  > 0 : needs swap
@@ -4051,7 +4051,7 @@ static int need_nhdr_swap( short dim0, int hdrsize )
       }
 
       return -1;        /* bad, naughty d0 */
-   } 
+   }
 
    /* dim[0] == 0 should not happen, but could, so try hdrsize */
    if( hsize == sizeof(nifti_1_header) ) return 0;
@@ -4232,7 +4232,7 @@ static int has_ascii_header( znzFile fp )
 /*! nifti_read_ascii_image  - process as a type-3 .nia image file
 
    return NULL on failure
-  
+
    NOTE: this is NOT part of the NIFTI-1 standard
 *//*--------------------------------------------------------------------*/
 nifti_image * nifti_read_ascii_image(znzFile fp, char *fname, int flen,
@@ -4319,7 +4319,7 @@ static int nifti_read_extensions( nifti_image *nim, znzFile fp, int remain )
    }
 
    posn = znztell(fp);
- 
+
    if( (posn != sizeof(nifti_1_header)) &&
        (nim->nifti_type != NIFTI_FTYPE_ASCII) )
       fprintf(stderr,"** WARNING: posn not header size (%d, %d)\n",
@@ -4440,7 +4440,7 @@ static int nifti_add_exten_to_list( nifti1_extension *  new_ext,
                                     nifti1_extension ** list, int new_length )
 {
    nifti1_extension * tmplist;
-  
+
    tmplist = *list;
    *list = (nifti1_extension *)malloc(new_length * sizeof(nifti1_extension));
 
@@ -4871,7 +4871,7 @@ int nifti_image_load( nifti_image *nim )
 
    This function does not allocate memory, so dataptr must be valid.
 *//*--------------------------------------------------------------------*/
-size_t nifti_read_buffer(znzFile fp, void* dataptr, size_t ntot, 
+size_t nifti_read_buffer(znzFile fp, void* dataptr, size_t ntot,
                                 nifti_image *nim)
 {
   size_t ii;
@@ -4883,9 +4883,9 @@ size_t nifti_read_buffer(znzFile fp, void* dataptr, size_t ntot,
   }
 
   ii = znzread( dataptr , 1 , ntot , fp ) ;             /* data input */
-  
+
   /* if read was short, fail */
-  if( ii < ntot ){ 
+  if( ii < ntot ){
     if( g_opts.debug > 0 )
        fprintf(stderr,"++ WARNING: nifti_read_buffer(%s):\n"
                "   data bytes needed = %u\n"
@@ -4899,9 +4899,9 @@ size_t nifti_read_buffer(znzFile fp, void* dataptr, size_t ntot,
 
   if( g_opts.debug > 2 )
     fprintf(stderr,"+d nifti_read_buffer: read %u bytes\n", (unsigned)ii);
-  
+
   /* byte swap array if needed */
-  
+
   if( nim->swapsize > 1 && nim->byteorder != nifti_short_order() )
     nifti_swap_Nbytes( (int)(ntot / nim->swapsize ), nim->swapsize , dataptr ) ;
 
@@ -4909,9 +4909,9 @@ size_t nifti_read_buffer(znzFile fp, void* dataptr, size_t ntot,
 {
   /* check input float arrays for goodness, and fix bad floats */
   int fix_count = 0 ;
-  
+
   switch( nim->datatype ){
-    
+
     case NIFTI_TYPE_FLOAT32:
     case NIFTI_TYPE_COMPLEX64:{
         register float *far = (float *)dataptr ; register size_t jj,nj ;
@@ -4923,7 +4923,7 @@ size_t nifti_read_buffer(znzFile fp, void* dataptr, size_t ntot,
            }
       }
       break ;
-    
+
     case NIFTI_TYPE_FLOAT64:
     case NIFTI_TYPE_COMPLEX128:{
         register double *far = (double *)dataptr ; register size_t jj,nj ;
@@ -4935,14 +4935,14 @@ size_t nifti_read_buffer(znzFile fp, void* dataptr, size_t ntot,
            }
       }
       break ;
-    
+
   }
 
   if( g_opts.debug > 1 )
      fprintf(stderr,"+d in image, %d bad floats were set to 0\n", fix_count);
 }
 #endif
-  
+
   return ii;
 }
 
@@ -5058,7 +5058,7 @@ size_t nifti_write_buffer(znzFile fp, const void *buffer, size_t numbytes)
    \param  fp  : File pointer
    \param  nim : nifti_image corresponding to the data
    \param  NBL : optional source of write data (if NULL use nim->data)
-  
+
    \return 0 on success, -1 on failure
 
    Note: the nifti_image byte_order is set as that of the current CPU.
@@ -5185,9 +5185,9 @@ nifti_image* nifti_simple_init_nim(void)
   nifti_image *nim;
   struct nifti_1_header nhdr;
   int nbyper, swapsize;
-  
+
    memset(&nhdr,0,sizeof(nhdr)) ;  /* zero out header, to be safe */
-  
+
    nhdr.sizeof_hdr = sizeof(nhdr) ;
    nhdr.regular    = 'r' ;           /* for some stupid reason */
 
@@ -5217,7 +5217,7 @@ nifti_image* nifti_simple_init_nim(void)
 
    Return an allocated nifti_1_header struct, based on the given
    dimensions and datatype.
- 
+
    \param arg_dims  : optional dim[8] array (default {3,1,1,1,0,0,0,0})
    \param arg_dtype : optional datatype (default DT_FLOAT32)
 
@@ -5230,7 +5230,7 @@ nifti_1_header * nifti_make_new_header(const int arg_dims[], int arg_dtype)
    const int      * dim;  /* either passed or default dims  */
    int              dtype; /* either passed or default dtype */
    int              c, nbyper, swapsize;
-  
+
    /* if arg_dims is passed, apply it */
    if( arg_dims ) dim = arg_dims;
    else           dim = default_dims;
@@ -5268,7 +5268,7 @@ nifti_1_header * nifti_make_new_header(const int arg_dims[], int arg_dtype)
       fprintf(stderr,"** nifti_make_new_header: failed to alloc hdr\n");
       return NULL;
    }
-  
+
    nhdr->sizeof_hdr = sizeof(nifti_1_header) ;
    nhdr->regular    = 'r' ;           /* for some stupid reason */
 
@@ -5295,7 +5295,7 @@ nifti_1_header * nifti_make_new_header(const int arg_dims[], int arg_dtype)
 
    Create a nifti_image from the given dimensions and data type.
    Optinally, allocate zero-filled data.
-  
+
    \param dims      : optional dim[8]   (default {3,1,1,1,0,0,0,0})
    \param datatype  : optional datatype (default DT_FLOAT32)
    \param data_fill : if flag is set, allocate zero-filled data for image
@@ -5596,7 +5596,7 @@ void nifti_set_iname_offset(nifti_image *nim)
    \sa nifti_image_write, nifti_image_write_hdr_img2, nifti_image_free,
        nifti_set_filenames
 *//*--------------------------------------------------------------------*/
-znzFile nifti_image_write_hdr_img( nifti_image *nim , int write_data , 
+znzFile nifti_image_write_hdr_img( nifti_image *nim , int write_data ,
                                           const char* opts )
 {
   return nifti_image_write_hdr_img2(nim,write_data,opts,NULL,NULL);
@@ -5615,7 +5615,7 @@ znzFile nifti_image_write_hdr_img( nifti_image *nim , int write_data ,
  * If the image data file is left open it returns a valid znzFile handle.
  * It also uses imgfile as the open image file is not null, and modifies
  * it inside.
- * 
+ *
  * \param nim        nifti_image to write to disk
  * \param write_opts flags whether to write data and/or close file (see below)
  * \param opts       file-open options, probably "wb" from nifti_image_write()
@@ -5623,18 +5623,18 @@ znzFile nifti_image_write_hdr_img( nifti_image *nim , int write_data ,
                      (may be NULL)
  * \param NBL        optional nifti_brick_list, containing the image data
                      (may be NULL)
- * 
+ *
  * Values for write_opts mode are based on two binary flags
  * ( 0/1 for no-write/write data, and 0/2 for close/leave-open files ) :
  *    -   0 = do not write data and close (do not open data file)
  *    -   1 = write data        and close
- *    -   2 = do not write data and leave data file open 
- *    -   3 = write data        and leave data file open 
+ *    -   2 = do not write data and leave data file open
+ *    -   3 = write data        and leave data file open
  *
  * \sa nifti_image_write, nifti_image_write_hdr_img, nifti_image_free,
  *     nifti_set_filenames
 *//*---------------------------------------------------------------------*/
-znzFile nifti_image_write_hdr_img2(nifti_image *nim, int write_opts, 
+znzFile nifti_image_write_hdr_img2(nifti_image *nim, int write_opts,
                const char * opts, znzFile imgfile, const nifti_brick_list * NBL)
 {
    struct nifti_1_header nhdr ;
@@ -5674,7 +5674,7 @@ znzFile nifti_image_write_hdr_img2(nifti_image *nim, int write_opts,
        }
        if( nim->iname == NULL ){ /* then make a new one */
          nim->iname = nifti_makeimgname(nim->fname,nim->nifti_type,0,0);
-         if( nim->iname == NULL ) return NULL;  
+         if( nim->iname == NULL ) return NULL;
        }
    }
 
@@ -5742,20 +5742,20 @@ znzFile nifti_write_ascii_image(nifti_image *nim, const nifti_brick_list * NBL,
 {
    znzFile   fp;
    char    * hstr;
-                                                                                
+
    hstr = nifti_image_to_ascii( nim ) ;  /* get header in ASCII form */
    if( ! hstr ){ fprintf(stderr,"** failed image_to_ascii()\n"); return NULL; }
-                                                                                
+
    fp = znzopen( nim->fname , opts , nifti_is_gzfile(nim->fname) ) ;
    if( znz_isnull(fp) ){
       free(hstr);
       fprintf(stderr,"** failed to open '%s' for ascii write\n",nim->fname);
       return fp;
    }
-                                                                                
+
    znzputs(hstr,fp);                                               /* header */
    nifti_write_extensions(fp,nim);                             /* extensions */
-                                                                                
+
    if ( write_data   ) { nifti_write_all_data(fp,nim,NBL); }         /* data */
    if ( ! leave_open ) { znzclose(fp); }
    free(hstr);
@@ -6839,7 +6839,7 @@ int nifti_read_subregion_image( nifti_image * nim,
       }
     }
 
-  /* if you get through all the dimensions without hitting 
+  /* if you get through all the dimensions without hitting
   ** a subrange of size > 1, a collapsed read is possible
   */
   if(i > nim->ndim)
@@ -6868,7 +6868,7 @@ int nifti_read_subregion_image( nifti_image * nim,
   /* the current offset is just past the nifti header, save
    * location so that SEEK_SET can be used below
    */
-  initial_offset = znztell(fp);  
+  initial_offset = znztell(fp);
   /* get strides*/
   compute_strides(strides,image_size,nim->nbyper);
 

--- a/lib/lib-memory/lib-memory-io.c
+++ b/lib/lib-memory/lib-memory-io.c
@@ -357,8 +357,8 @@ Tree *pt_memory_io_load_file_dicom (Tree **patient_tree, char *pc_path)
     return NULL;
   }
 
-  ps_serie->matrix.z=(ps_serie->matrix.z==0) ? i16_NumberOfSlices/ps_serie->num_time_series : 1;
-  i16_NumberOfReconstructions=(short int)(ps_serie->matrix.z)/(i16_MaximumReferenceOrderValue - i16_MinimumReferenceOrderValue + 1);
+  ps_serie->matrix.i16_z=(ps_serie->matrix.i16_z==0) ? i16_NumberOfSlices/ps_serie->num_time_series : 1;
+  i16_NumberOfReconstructions=(short int)(ps_serie->matrix.i16_z)/(i16_MaximumReferenceOrderValue - i16_MinimumReferenceOrderValue + 1);
 
   if (i16_NumberOfReconstructions <= 1)
   {
@@ -367,7 +367,7 @@ Tree *pt_memory_io_load_file_dicom (Tree **patient_tree, char *pc_path)
   }
   else
   {
-    ps_serie->matrix.z= ps_serie->matrix.z/i16_NumberOfReconstructions;
+    ps_serie->matrix.i16_z= ps_serie->matrix.i16_z/i16_NumberOfReconstructions;
     ps_serie->num_time_series*=i16_NumberOfReconstructions;
   }
 
@@ -432,13 +432,6 @@ Tree *pt_memory_io_load_file_dicom (Tree **patient_tree, char *pc_path)
     pll_dicomFilesIter = list_next(pll_dicomFilesIter);
   }
   list_free(pll_dicomFiles);
-
-  ps_serie->d_Qfac=1;
-  ps_serie->i16_QuaternionCode=0;
-  ps_serie->i16_StandardSpaceCode=0;
-  ps_serie->input_type=MUMC_FILETYPE_DICOM;
-  ps_serie->raw_data_type=MEMORY_TYPE_UINT16;
-  ps_serie->u8_AxisUnits=0;
 
   memory_serie_set_upper_and_lower_borders_from_data(ps_serie);
 

--- a/lib/lib-memory/lib-memory-slice.c
+++ b/lib/lib-memory/lib-memory-slice.c
@@ -49,9 +49,10 @@
 /*                                                                                                    */
 float f_MinimumValue(Vector3D *ps_InputVector);
 
-Coordinate3D s_GetCurrentPositionInBlob(float f_Depth, Vector3D *ps_NormalVector, Vector3D *ps_PivotPoint)
+
+Vector3D s_GetCurrentPosition(float f_Depth, Vector3D *ps_NormalVector, Vector3D *ps_PivotPoint)
 {
-  Coordinate3D ts_PositionVector;
+  Vector3D ts_PositionVector;
 
   ts_PositionVector.x = f_Depth * ps_NormalVector->x + ps_PivotPoint->x;
   ts_PositionVector.y = f_Depth * ps_NormalVector->y + ps_PivotPoint->y;
@@ -172,6 +173,25 @@ float f_MaximumValue(Vector3D *ps_InputVector)
   }
 }
 
+short int i16_MaximumValue(ts_Vector3DInt *ps_InputVector)
+{
+  debug_functions ();
+
+  if ((ps_InputVector->i16_x >= ps_InputVector->i16_y) && (ps_InputVector->i16_x >= ps_InputVector->i16_z))
+  {
+    return ps_InputVector->i16_x;
+  }
+  else if ((ps_InputVector->i16_y >= ps_InputVector->i16_x) && (ps_InputVector->i16_y >= ps_InputVector->i16_z))
+  {
+    return ps_InputVector->i16_y;
+  }
+  else
+  {
+    return ps_InputVector->i16_z;
+  }
+}
+
+
 float f_MinimumValue(Vector3D *ps_InputVector)
 {
   debug_functions ();
@@ -190,6 +210,24 @@ float f_MinimumValue(Vector3D *ps_InputVector)
   }
 }
 
+short int  i16_MinimumValue(ts_Vector3DInt *ps_InputVector)
+{
+  debug_functions ();
+
+  if ((ps_InputVector->i16_x < ps_InputVector->i16_y) && (ps_InputVector->i16_x < ps_InputVector->i16_z))
+  {
+    return ps_InputVector->i16_x;
+  }
+  else if ((ps_InputVector->i16_y < ps_InputVector->i16_x) && (ps_InputVector->i16_y < ps_InputVector->i16_z))
+  {
+    return ps_InputVector->i16_y;
+  }
+  else
+  {
+    return ps_InputVector->i16_z;
+  }
+}
+
 
 /*                                                                                                    */
 /*                                                                                                    */
@@ -205,14 +243,16 @@ memory_slice_get_data (Slice *slice)
   Serie *serie = slice->serie;
   assert (serie != NULL);
 
-  Vector3D ts_pointInPlane;
+  ts_Vector3DInt ts_pointInPlane;
+
+  Vector3D ts_floatingPointInPlane;
   Vector3D ts_PositionVector;
   Vector3D ts_TmpPosition;
+  Vector3D ts_PivotVectorInBlob;
 
   Vector3D ts_Startpoint;
   Vector3D ts_EndPoint;
   Vector3D ts_Delta;
-
 
   ViewportProperties *p_ViewportProps = &slice->viewportProperties;
 
@@ -230,8 +270,6 @@ memory_slice_get_data (Slice *slice)
   void *pv_OrigData = NULL;
   void **ppv_Data = NULL;
   void **ppv_CntData = NULL;
-
-
   slice->i16_ViewportChange=1;
 
   if (slice->i16_ViewportChange)
@@ -242,130 +280,177 @@ memory_slice_get_data (Slice *slice)
     +-------------------------------------------------------------------------------*/
     *slice->ps_NormalVector = s_normalize(slice->ps_NormalVector);
 
-    slice->ps_NormalVector->x = slice->ps_NormalVector->x;
-    slice->ps_NormalVector->y = slice->ps_NormalVector->y;
-    slice->ps_NormalVector->z = slice->ps_NormalVector->z;
+    p_ViewportProps->ts_normalVector.x=slice->ps_NormalVector->x;
+    p_ViewportProps->ts_normalVector.y=slice->ps_NormalVector->y;
+    p_ViewportProps->ts_normalVector.z=slice->ps_NormalVector->z;
 
-    p_ViewportProps->ts_perpendicularVector = s_perpendicular(slice->ps_NormalVector, slice->ps_upVector);
-    p_ViewportProps->ts_crossproductVector = s_crossproduct(slice->ps_NormalVector,&p_ViewportProps->ts_perpendicularVector);
+    p_ViewportProps->ts_perpendicularVector = s_perpendicular(&p_ViewportProps->ts_normalVector, slice->ps_upVector);
+    p_ViewportProps->ts_crossproductVector = s_crossproduct(&p_ViewportProps->ts_normalVector,&p_ViewportProps->ts_perpendicularVector);
 
     /*------------------------------------------------------------------------------+
-    | STEP 2 Translate viewport vectors to a plane, get actual width and height     |
-    |        of the image                                                           |
-    +-------------------------------------------------------------------------------*/
-    ts_pointInPlane.x = (fabs(p_ViewportProps->ts_perpendicularVector.x) * serie->matrix.x);
-    ts_pointInPlane.y = (fabs(p_ViewportProps->ts_perpendicularVector.y) * serie->matrix.y);
-    ts_pointInPlane.z = (fabs(p_ViewportProps->ts_perpendicularVector.z) * serie->matrix.z);
-
-    slice->matrix.y = f_MaximumValue(&ts_pointInPlane);
-
-    ts_pointInPlane.x = (fabs(p_ViewportProps->ts_crossproductVector.x) * serie->matrix.x);
-    ts_pointInPlane.y = (fabs(p_ViewportProps->ts_crossproductVector.y) * serie->matrix.y);
-    ts_pointInPlane.z = (fabs(p_ViewportProps->ts_crossproductVector.z) * serie->matrix.z);
-
-    slice->matrix.x = f_MaximumValue(&ts_pointInPlane);
-    /*------------------------------------------------------------------------------+
-    | STEP 3 Calculate the direction to build the image from                        |
+    | STEP 2 Calculate the direction to build the image from                        |
     |        (e.g. left to right, or right to left)                                 |
     +-------------------------------------------------------------------------------*/
-    ts_pointInPlane.x = 0;
-    ts_pointInPlane.y = 0;
-    ts_pointInPlane.z = 0;
+    ts_floatingPointInPlane.x = 0;
+    ts_floatingPointInPlane.y = 0;
+    ts_floatingPointInPlane.z = 0;
 
-    ts_Startpoint = ts_memory_matrix_multiply4x4(serie->pt_RotationMatrix, &ts_pointInPlane);
+    ts_Startpoint = ts_memory_matrix_multiply4x4(serie->pt_RotationMatrix, &ts_floatingPointInPlane);
 
-    ts_pointInPlane.x = p_ViewportProps->ts_perpendicularVector.x;
-    ts_pointInPlane.y = p_ViewportProps->ts_perpendicularVector.y;
-    ts_pointInPlane.z = p_ViewportProps->ts_perpendicularVector.z;
+    ts_floatingPointInPlane.x = p_ViewportProps->ts_perpendicularVector.x;
+    ts_floatingPointInPlane.y = p_ViewportProps->ts_perpendicularVector.y;
+    ts_floatingPointInPlane.z = p_ViewportProps->ts_perpendicularVector.z;
 
-    ts_EndPoint = ts_memory_matrix_multiply4x4(serie->pt_RotationMatrix, &ts_pointInPlane);
-
-    ts_Delta.x = ts_Startpoint.x - ts_EndPoint.x;
-    ts_Delta.y = ts_Startpoint.y - ts_EndPoint.y;
-    ts_Delta.z = ts_Startpoint.z - ts_EndPoint.z;
-
-    p_ViewportProps->i32_StrideHeight = (f_MinimumValue(&ts_Delta) < 0) ? -1 : 1;
-
-
-    ts_pointInPlane.x = p_ViewportProps->ts_crossproductVector.x;
-    ts_pointInPlane.y = p_ViewportProps->ts_crossproductVector.y;
-    ts_pointInPlane.z = p_ViewportProps->ts_crossproductVector.z;
-
-    ts_EndPoint = ts_memory_matrix_multiply4x4(serie->pt_RotationMatrix, &ts_pointInPlane);
+    ts_EndPoint = ts_memory_matrix_multiply4x4(serie->pt_RotationMatrix, &ts_floatingPointInPlane);
 
     ts_Delta.x = ts_Startpoint.x - ts_EndPoint.x;
     ts_Delta.y = ts_Startpoint.y - ts_EndPoint.y;
     ts_Delta.z = ts_Startpoint.z - ts_EndPoint.z;
 
-    p_ViewportProps->i32_StrideWidth = (f_MinimumValue(&ts_Delta) < 0) ? -1 : 1;
+    p_ViewportProps->i16_StrideHeight = (f_MinimumValue(&ts_Delta) < 0) ? -1 : 1;
 
-    ts_pointInPlane.x = slice->ps_NormalVector->x;
-    ts_pointInPlane.y = slice->ps_NormalVector->y;
-    ts_pointInPlane.z = slice->ps_NormalVector->z;
+    ts_floatingPointInPlane.x = p_ViewportProps->ts_crossproductVector.x;
+    ts_floatingPointInPlane.y = p_ViewportProps->ts_crossproductVector.y;
+    ts_floatingPointInPlane.z = p_ViewportProps->ts_crossproductVector.z;
 
-    ts_EndPoint = ts_memory_matrix_multiply4x4(serie->pt_RotationMatrix, &ts_pointInPlane);
+    ts_EndPoint = ts_memory_matrix_multiply4x4(serie->pt_RotationMatrix, &ts_floatingPointInPlane);
 
     ts_Delta.x = ts_Startpoint.x - ts_EndPoint.x;
     ts_Delta.y = ts_Startpoint.y - ts_EndPoint.y;
     ts_Delta.z = ts_Startpoint.z - ts_EndPoint.z;
 
-    f_CurrentDepth = (f_MinimumValue(&ts_Delta) < 0) ? slice->matrix.z : -slice->matrix.z;
+    p_ViewportProps->i16_StrideWidth = (f_MinimumValue(&ts_Delta) < 0) ? -1 : 1;
 
+    ts_floatingPointInPlane.x = p_ViewportProps->ts_normalVector.x;
+    ts_floatingPointInPlane.y = p_ViewportProps->ts_normalVector.y;
+    ts_floatingPointInPlane.z = p_ViewportProps->ts_normalVector.z;
+
+    ts_EndPoint = ts_memory_matrix_multiply4x4(serie->pt_RotationMatrix, &ts_floatingPointInPlane);
+
+    ts_Delta.x = ts_Startpoint.x - ts_EndPoint.x;
+    ts_Delta.y = ts_Startpoint.y - ts_EndPoint.y;
+    ts_Delta.z = ts_Startpoint.z - ts_EndPoint.z;
+
+    p_ViewportProps->i16_StrideDepth = (f_MinimumValue(&ts_Delta) < 0) ? -1 : 1;
+    /*------------------------------------------------------------------------------+
+    | STEP 3 Translate viewport vectors to a plane, get actual width and height     |
+    |        of the image                                                           |
+    +-------------------------------------------------------------------------------*/
+    ts_pointInPlane.i16_x = (fabs(p_ViewportProps->ts_perpendicularVector.x) * serie->matrix.i16_x);
+    ts_pointInPlane.i16_y = (fabs(p_ViewportProps->ts_perpendicularVector.y) * serie->matrix.i16_y);
+    ts_pointInPlane.i16_z = (fabs(p_ViewportProps->ts_perpendicularVector.z) * serie->matrix.i16_z);
+
+    slice->matrix.i16_y = i16_MaximumValue(&ts_pointInPlane);
+
+    ts_pointInPlane.i16_x = (fabs(p_ViewportProps->ts_crossproductVector.x) * serie->matrix.i16_x);
+    ts_pointInPlane.i16_y = (fabs(p_ViewportProps->ts_crossproductVector.y) * serie->matrix.i16_y);
+    ts_pointInPlane.i16_z = (fabs(p_ViewportProps->ts_crossproductVector.z) * serie->matrix.i16_z);
+
+    slice->matrix.i16_x = i16_MaximumValue(&ts_pointInPlane);
 
     /*------------------------------------------------------------------------------+
     | STEP 4 Calculate the starting and ending point of the width and height        |
     +-------------------------------------------------------------------------------*/
-    ts_PositionVector = s_GetCurrentPositionInBlob(f_CurrentDepth, slice->ps_NormalVector, slice->ps_PivotPoint);
+
+    ts_PivotVectorInBlob = ts_memory_matrix_multiply4x4(serie->pt_InverseMatrix, slice->ps_PivotPoint);
+    ts_PositionVector = s_GetCurrentPosition(slice->matrix.i16_z,&p_ViewportProps->ts_normalVector, &ts_PivotVectorInBlob);
 
     p_ViewportProps->i16_StartHeight = 0;
-    p_ViewportProps->i16_StopHeight = 1;
+    p_ViewportProps->i16_StopHeight = 0;
 
-    for(i16_heightCnt=0; i16_heightCnt < slice->matrix.y; i16_heightCnt++)
+    for(i16_heightCnt=0; i16_heightCnt < slice->matrix.i16_y; i16_heightCnt++)
     {
       ts_PositionVector.x += p_ViewportProps->ts_perpendicularVector.x;
       ts_PositionVector.y += p_ViewportProps->ts_perpendicularVector.y;
       ts_PositionVector.z += p_ViewportProps->ts_perpendicularVector.z;
 
-      if ((ts_PositionVector.x > serie->matrix.x) || (ts_PositionVector.y > serie->matrix.y) || (ts_PositionVector.z > serie->matrix.z))
+      if ((ts_PositionVector.x > serie->matrix.i16_x) || (ts_PositionVector.y > serie->matrix.i16_y) || (ts_PositionVector.z > serie->matrix.i16_z))
       {
         p_ViewportProps->i16_StopHeight = i16_heightCnt;
-        p_ViewportProps->i16_StartHeight = p_ViewportProps->i16_StopHeight - slice->matrix.y;
+        p_ViewportProps->i16_StartHeight = p_ViewportProps->i16_StopHeight - slice->matrix.i16_y;
         break;
       }
 
       if ((ts_PositionVector.x < 0) || (ts_PositionVector.y < 0) || (ts_PositionVector.z < 0))
       {
         p_ViewportProps->i16_StartHeight = -i16_heightCnt;
-        p_ViewportProps->i16_StopHeight = p_ViewportProps->i16_StartHeight + slice->matrix.y;
+        p_ViewportProps->i16_StopHeight = p_ViewportProps->i16_StartHeight + slice->matrix.i16_y;
         break;
       }
     }
 
-    ts_PositionVector = s_GetCurrentPositionInBlob(f_CurrentDepth, slice->ps_NormalVector, slice->ps_PivotPoint);
+    if  ((p_ViewportProps->i16_StartHeight == 0 ) && (p_ViewportProps->i16_StopHeight == 0))
+    {
+      if (f_MaximumValue(&p_ViewportProps->ts_perpendicularVector) > 0)
+      {
+        p_ViewportProps->i16_StartHeight = 0;
+        p_ViewportProps->i16_StopHeight = slice->matrix.i16_y;
+      }
+      else
+      {
+        p_ViewportProps->i16_StartHeight = -slice->matrix.i16_y;
+        p_ViewportProps->i16_StopHeight = 0;
+      }
+    }
+
+
+    ts_PivotVectorInBlob = ts_memory_matrix_multiply4x4(serie->pt_InverseMatrix, slice->ps_PivotPoint);
+    ts_PositionVector = s_GetCurrentPosition(slice->matrix.i16_z,&p_ViewportProps->ts_normalVector, &ts_PivotVectorInBlob);
+
 
     p_ViewportProps->i16_StartWidth = 0;
-    p_ViewportProps->i16_StopWidth = 1;
+    p_ViewportProps->i16_StopWidth = 0;
 
-    for(i16_widthCnt=0; i16_widthCnt < slice->matrix.x; i16_widthCnt++)
+    for(i16_widthCnt=0; i16_widthCnt < slice->matrix.i16_x; i16_widthCnt++)
     {
       ts_PositionVector.x += p_ViewportProps->ts_crossproductVector.x;
       ts_PositionVector.y += p_ViewportProps->ts_crossproductVector.y;
       ts_PositionVector.z += p_ViewportProps->ts_crossproductVector.z;
 
-      if ((ts_PositionVector.x > serie->matrix.x) || (ts_PositionVector.y > serie->matrix.y) || (ts_PositionVector.z > serie->matrix.z))
+      if ((ts_PositionVector.x > serie->matrix.i16_x) || (ts_PositionVector.y > serie->matrix.i16_y) || (ts_PositionVector.z > serie->matrix.i16_z))
       {
         p_ViewportProps->i16_StopWidth = i16_widthCnt;
-        p_ViewportProps->i16_StartWidth = p_ViewportProps->i16_StopWidth - slice->matrix.x;
+        p_ViewportProps->i16_StartWidth = p_ViewportProps->i16_StopWidth - slice->matrix.i16_x;
         break;
       }
 
       if ((ts_PositionVector.x < 0) || (ts_PositionVector.y < 0) || (ts_PositionVector.z < 0))
       {
         p_ViewportProps->i16_StartWidth = -i16_widthCnt;
-        p_ViewportProps->i16_StopWidth = p_ViewportProps->i16_StartWidth + slice->matrix.x;
+        p_ViewportProps->i16_StopWidth = p_ViewportProps->i16_StartWidth + slice->matrix.i16_x;
         break;
       }
     }
+
+    if  ((p_ViewportProps->i16_StartWidth == 0 ) && (p_ViewportProps->i16_StopWidth == 0))
+    {
+      if (f_MaximumValue(&p_ViewportProps->ts_crossproductVector) > 0)
+      {
+        p_ViewportProps->i16_StartWidth = 0;
+        p_ViewportProps->i16_StopWidth = slice->matrix.i16_x;
+      }
+      else
+      {
+        p_ViewportProps->i16_StartWidth = -slice->matrix.i16_x;
+        p_ViewportProps->i16_StopWidth = 0;
+      }
+    }
+
+    short int i16_tmp;
+    if (p_ViewportProps->i16_StrideHeight == -1)
+    {
+      i16_tmp = p_ViewportProps->i16_StartHeight;
+      p_ViewportProps->i16_StartHeight = p_ViewportProps->i16_StopHeight-1;
+      p_ViewportProps->i16_StopHeight = i16_tmp-1;
+    }
+
+    if (p_ViewportProps->i16_StrideWidth == -1)
+    {
+      i16_tmp = p_ViewportProps->i16_StartWidth;
+      p_ViewportProps->i16_StartWidth = p_ViewportProps->i16_StopWidth-1;
+      p_ViewportProps->i16_StopWidth = i16_tmp-1;
+    }
+
 
     /*------------------------------------------------------------------------------+
     | STEP 5 Calculate the scaling parameters                                       |
@@ -391,47 +476,26 @@ memory_slice_get_data (Slice *slice)
       slice->f_ScaleFactorY=slice->f_ScaleFactorY/slice->f_ScaleFactorX;
       slice->f_ScaleFactorX=1;
     }
-    p_ViewportProps->i16_StartHeight /= p_ViewportProps->i32_StrideHeight;
-    p_ViewportProps->i16_StopHeight /= p_ViewportProps->i32_StrideHeight;
-
-    p_ViewportProps->i16_StartWidth /= p_ViewportProps->i32_StrideWidth;
-    p_ViewportProps->i16_StopWidth /= p_ViewportProps->i32_StrideWidth;
 
     slice->i16_ViewportChange = 0;
   }
-
-  ts_pointInPlane.x = 0;
-  ts_pointInPlane.y = 0;
-  ts_pointInPlane.z = 0;
-
-  ts_Startpoint = ts_memory_matrix_multiply4x4(serie->pt_RotationMatrix, &ts_pointInPlane);
-
-  ts_pointInPlane.x = slice->ps_NormalVector->x;
-  ts_pointInPlane.y = slice->ps_NormalVector->y;
-  ts_pointInPlane.z = slice->ps_NormalVector->z;
-
-  ts_EndPoint = ts_memory_matrix_multiply4x4(serie->pt_RotationMatrix, &ts_pointInPlane);
-
-  ts_Delta.x = ts_Startpoint.x - ts_EndPoint.x;
-  ts_Delta.y = ts_Startpoint.y - ts_EndPoint.y;
-  ts_Delta.z = ts_Startpoint.z - ts_EndPoint.z;
-
-  f_CurrentDepth = (f_MinimumValue(&ts_Delta) < 0) ? slice->matrix.z : -slice->matrix.z;
-
-
 
   /*------------------------------------------------------------------------------+
   | STEP 6 Calculate the scaling parameters                                       |
   +-------------------------------------------------------------------------------*/
 
-  ts_PositionVector = s_GetCurrentPositionInBlob(f_CurrentDepth, slice->ps_NormalVector, slice->ps_PivotPoint);
+
+  ts_PivotVectorInBlob = ts_memory_matrix_multiply4x4(serie->pt_InverseMatrix, slice->ps_PivotPoint);
+  ts_PositionVector = s_GetCurrentPosition(slice->matrix.i16_z,&p_ViewportProps->ts_normalVector, &ts_PivotVectorInBlob);
+//  printf("blob position [x,y,z]: [%10.4f, %10.4f, %10.4f]\n",ts_PositionVector.x, ts_PositionVector.y, ts_PositionVector.z);
+
 
   i16_BytesToRead = memory_serie_get_memory_space (serie);
-  i32_MemoryInBlob = serie->matrix.z * serie->matrix.y * serie->matrix.x * i16_BytesToRead;
+  i32_MemoryInBlob = serie->matrix.i16_z * serie->matrix.i16_y * serie->matrix.i16_x * i16_BytesToRead;
 
-  i32_MemoryPerSlice = slice->matrix.x * slice->matrix.y * sizeof (void *);
-  i32_MemoryTimeSerieOffset = serie->matrix.z * serie->matrix.y *
-                              serie->matrix.x * i16_BytesToRead *
+  i32_MemoryPerSlice = slice->matrix.i16_x * slice->matrix.i16_y * sizeof (void *);
+  i32_MemoryTimeSerieOffset = serie->matrix.i16_z * serie->matrix.i16_y *
+                              serie->matrix.i16_x * i16_BytesToRead *
                               slice->u16_timePoint;
 
   ppv_Data = calloc (1, i32_MemoryPerSlice);
@@ -443,10 +507,6 @@ memory_slice_get_data (Slice *slice)
   short int i16_positionX;
   short int i16_positionY;
   short int i16_positionZ;
-
-  short int i16_MatrixX=(short int)(serie->matrix.x);
-  short int i16_MatrixY=(short int)(serie->matrix.y);
-  short int i16_MatrixZ=(short int)(serie->matrix.z);
 
   /*
 
@@ -465,27 +525,15 @@ memory_slice_get_data (Slice *slice)
     i16_widthCnt=p_ViewportProps->i16_StartWidth;
     while (i16_widthCnt != p_ViewportProps->i16_StopWidth)
     {
-      if (p_ViewportProps->i32_StrideWidth > 0)
-      {
-        ts_TmpPosition.x +=  p_ViewportProps->ts_crossproductVector.x;
-        ts_TmpPosition.y +=  p_ViewportProps->ts_crossproductVector.y;
-        ts_TmpPosition.z +=  p_ViewportProps->ts_crossproductVector.z;
-      }
-      else
-      {
-        ts_TmpPosition.x -=  p_ViewportProps->ts_crossproductVector.x;
-        ts_TmpPosition.y -=  p_ViewportProps->ts_crossproductVector.y;
-        ts_TmpPosition.z -=  p_ViewportProps->ts_crossproductVector.z;
-      }
 
 
       i16_positionX=(short int)(floor(ts_TmpPosition.x));
       i16_positionY=(short int)(floor(ts_TmpPosition.y));
       i16_positionZ=(short int)(floor(ts_TmpPosition.z));
 
-      if ((i16_positionX > i16_MatrixX) ||
-          (i16_positionY > i16_MatrixY) ||
-          (i16_positionZ > i16_MatrixZ) ||
+      if ((i16_positionX > serie->matrix.i16_x) ||
+          (i16_positionY > serie->matrix.i16_y) ||
+          (i16_positionZ > serie->matrix.i16_z) ||
           (i16_positionX < 0) ||
           (i16_positionY < 0) ||
           (i16_positionZ < 0))
@@ -494,8 +542,8 @@ memory_slice_get_data (Slice *slice)
       }
       else
       {
-        i32_MemoryOffset  = ((int)(i16_positionZ * i16_MatrixX * i16_MatrixY) +
-                             (int)(i16_positionY * i16_MatrixX) +
+        i32_MemoryOffset  = ((int)(i16_positionZ * serie->matrix.i16_x * serie->matrix.i16_y) +
+                             (int)(i16_positionY * serie->matrix.i16_x) +
                              (int)(i16_positionX)) * i16_BytesToRead;
 
 
@@ -514,10 +562,23 @@ memory_slice_get_data (Slice *slice)
       *ppv_CntData=MEMORY_CAST(serie->data_type,pv_OrigData);
       ppv_CntData++;
 
+      if (p_ViewportProps->i16_StrideWidth > 0)
+      {
+        ts_TmpPosition.x +=  p_ViewportProps->ts_crossproductVector.x;
+        ts_TmpPosition.y +=  p_ViewportProps->ts_crossproductVector.y;
+        ts_TmpPosition.z +=  p_ViewportProps->ts_crossproductVector.z;
+      }
+      else
+      {
+        ts_TmpPosition.x -=  p_ViewportProps->ts_crossproductVector.x;
+        ts_TmpPosition.y -=  p_ViewportProps->ts_crossproductVector.y;
+        ts_TmpPosition.z -=  p_ViewportProps->ts_crossproductVector.z;
+      }
 
-      i16_widthCnt += p_ViewportProps->i32_StrideWidth;
+
+      i16_widthCnt += p_ViewportProps->i16_StrideWidth;
     }
-    i16_heightCnt += p_ViewportProps->i32_StrideHeight;
+    i16_heightCnt += p_ViewportProps->i16_StrideHeight;
   }
 
 
@@ -567,7 +628,7 @@ memory_slice_get_next (Slice *slice)
 {
   debug_functions ();
 
-  slice->matrix.z += 1;
+  slice->matrix.i16_z += 1;
 
   if (slice->data != NULL)
     free (slice->data), slice->data = NULL;
@@ -583,7 +644,7 @@ memory_slice_get_previous (Slice *slice)
 {
   debug_functions ();
 
-  slice->matrix.z -= 1;
+  slice->matrix.i16_z -= 1;
 
   if (slice->data != NULL)
     free (slice->data), slice->data = NULL;
@@ -599,7 +660,7 @@ memory_slice_get_nth (Slice *slice, int nth)
 {
   debug_functions ();
 
-  slice->matrix.z = nth;
+  slice->matrix.i16_z = nth;
 
   if (slice->data != NULL)
     free (slice->data), slice->data = NULL;

--- a/lib/lib-pixeldata/lib-pixeldata.c
+++ b/lib/lib-pixeldata/lib-pixeldata.c
@@ -446,7 +446,7 @@ pixeldata_create_rgb_pixbuf (PixelData *pixeldata)
   Serie *serie = slice->serie;
   assert (serie != NULL);
 
-  pixeldata->rgb = realloc (pixeldata->rgb, sizeof (unsigned int) * slice->matrix.x * slice->matrix.y);
+  pixeldata->rgb = realloc (pixeldata->rgb, sizeof (unsigned int) * slice->matrix.i16_x * slice->matrix.i16_y);
 
   unsigned int *rgb = pixeldata->rgb;
   unsigned int *display_lookup_table = pixeldata->display_lookup_table;
@@ -456,7 +456,7 @@ pixeldata_create_rgb_pixbuf (PixelData *pixeldata)
 
   // TODO: What happens when *data_counter contains a negative value?
   unsigned int counter;
-  for (counter = 0; counter < (unsigned int)(slice->matrix.x * slice->matrix.y); counter++)
+  for (counter = 0; counter < (unsigned int)(slice->matrix.i16_x * slice->matrix.i16_y); counter++)
   {
     switch (serie->data_type)
     {
@@ -505,7 +505,7 @@ pixeldata_get_pixel_value_as_string (PixelData *pixeldata, Coordinate ts_Point)
   Slice *slice = PIXELDATA_ACTIVE_SLICE (pixeldata);
   assert (slice != NULL);
 
-  if ((ts_Point.x > slice->matrix.x || ts_Point.y > slice->matrix.y)
+  if ((ts_Point.x > slice->matrix.i16_x || ts_Point.y > slice->matrix.i16_y)
       || (ts_Point.x < 0 || ts_Point.y < 0))
   {
     sprintf (output, "-");
@@ -518,7 +518,7 @@ pixeldata_get_pixel_value_as_string (PixelData *pixeldata, Coordinate ts_Point)
   short int i16_X  = (short int)ts_Point.x;
   short int i16_Y  = (short int)ts_Point.y;
 
-  source += (unsigned int)(i16_Y * slice->matrix.x + i16_X);
+  source += (unsigned int)(i16_Y * slice->matrix.i16_x + i16_X);
 
   switch (pixeldata->serie->data_type)
   {
@@ -753,7 +753,6 @@ pixeldata_apply_brush (PixelData *ps_Original, PixelData *ps_Mask,
 {
   debug_functions ();
 
-  if (ts_End.x == 0 && ts_End.y == 0) return;
 
   if (ps_Mask == NULL) return;
   if (fp_BrushCallback == NULL) return;
@@ -778,17 +777,17 @@ pixeldata_set_voxel (PixelData *mask, PixelData *selection,
 
   // Boundary checks.
   if (point.x < 0 || point.y < 0) return 0;
-  if (point.x >= mask_slice->matrix.x || point.y >= mask_slice->matrix.y) return 0;
+  if (point.x >= mask_slice->matrix.i16_x || point.y >= mask_slice->matrix.i16_y) return 0;
 
   void **ppv_SelectionDataCounter = NULL;
   if (selection != NULL)
   {
     ppv_SelectionDataCounter = PIXELDATA_ACTIVE_SLICE_DATA (selection);
-    ppv_SelectionDataCounter += (unsigned int)(point.y * mask_slice->matrix.x + point.x);
+    ppv_SelectionDataCounter += (unsigned int)(point.y * mask_slice->matrix.i16_x + point.x);
   }
 
   void **ppv_ImageDataCounter = PIXELDATA_ACTIVE_SLICE_DATA (mask);
-  ppv_ImageDataCounter += (unsigned int)(point.y * mask_slice->matrix.x + point.x);
+  ppv_ImageDataCounter += (unsigned int)(point.y * mask_slice->matrix.i16_x + point.x);
 
   switch (mask->serie->data_type)
   {
@@ -832,13 +831,13 @@ pixeldata_get_voxel (PixelData *layer, Coordinate point, void *value)
 
   // Boundary checks.
   if (point.x < 0 || point.y < 0) return 0;
-  if (point.x >= mask_slice->matrix.x || point.y >= mask_slice->matrix.y) return 0;
+  if (point.x >= mask_slice->matrix.i16_x || point.y >= mask_slice->matrix.i16_y) return 0;
 
   short int i16_Y = (short int)point.y;
   short int i16_X = (short int)point.x;
 
   void **ppv_ImageDataCounter = PIXELDATA_ACTIVE_SLICE_DATA (layer);
-  ppv_ImageDataCounter += (unsigned int)(i16_Y * mask_slice->matrix.x + i16_X);
+  ppv_ImageDataCounter += (unsigned int)(i16_Y * mask_slice->matrix.i16_x + i16_X);
 
   switch (layer->serie->data_type)
   {

--- a/lib/lib-viewer/lib-viewer.c
+++ b/lib/lib-viewer/lib-viewer.c
@@ -347,7 +347,7 @@ viewer_on_mouse_scroll_prevnext (UNUSED ClutterActor *actor, ClutterEvent *event
       PIXELDATA_ACTIVE_SLICE (resources->ps_Original) =
         memory_slice_get_next (PIXELDATA_ACTIVE_SLICE (resources->ps_Original));
 
-      f_Z = PIXELDATA_ACTIVE_SLICE (resources->ps_Original)->matrix.z;
+      f_Z = PIXELDATA_ACTIVE_SLICE (resources->ps_Original)->matrix.i16_z;
 
       break;
      /*-----------------------------------------------------------------------.
@@ -357,13 +357,13 @@ viewer_on_mouse_scroll_prevnext (UNUSED ClutterActor *actor, ClutterEvent *event
       PIXELDATA_ACTIVE_SLICE (resources->ps_Original) =
         memory_slice_get_previous (PIXELDATA_ACTIVE_SLICE (resources->ps_Original));
 
-      f_Z = PIXELDATA_ACTIVE_SLICE (resources->ps_Original)->matrix.z;
+      f_Z = PIXELDATA_ACTIVE_SLICE (resources->ps_Original)->matrix.i16_z;
 
       break;
     default: break;
   }
 
-  f_Z = PIXELDATA_ACTIVE_SLICE (resources->ps_Original)->matrix.z;
+  f_Z = PIXELDATA_ACTIVE_SLICE (resources->ps_Original)->matrix.i16_z;
 
   viewer_update_slices (resources->pll_MaskSeries, f_Z);
   viewer_update_slices (resources->pll_OverlaySeries, f_Z);
@@ -498,13 +498,13 @@ viewer_update_text (Viewer *resources)
   char *pc_PixelValue = pixeldata_get_pixel_value_as_string (pixeldata, ts_PixelPosition);
 
   char *text = calloc (1, 110);
-  sprintf (text, "Slice:\t\t %-5.0f\n"
+  sprintf (text, "Slice:\t\t %d\n"
                  "Window/Level:\t %d / %d\n"
                  "Position:\t\t %.0f , %.0f\n"
                  "Zoom:\t\t %.0f%%\n"
                  "Value:\t\t %s\n"
                  "Macro:\t\t %s\n",
-                 slice->matrix.z,
+                 slice->matrix.i16_z,
                  pixeldata->ts_WWWL.i32_windowWidth, pixeldata->ts_WWWL.i32_windowLevel,
                  ts_PixelPosition.x, ts_PixelPosition.y,
                  resources->f_ZoomFactor * 100,
@@ -596,8 +596,8 @@ viewer_redraw (Viewer *resources, RedrawMode redraw_mode)
   Slice *slice = PIXELDATA_ACTIVE_SLICE (resources->ps_Original);
   assert (slice != NULL);
 
-  int i32_Width  = slice->matrix.x;
-  int i32_Height = slice->matrix.y;
+  int i32_Width  = slice->matrix.i16_x;
+  int i32_Height = slice->matrix.i16_y;
 
   /*--------------------------------------------------------------------------.
    | NON-MINIMAL REDRAW                                                       |
@@ -625,8 +625,8 @@ viewer_redraw (Viewer *resources, RedrawMode redraw_mode)
 
     ClutterActor *c_BaseImage;
     c_BaseImage = viewer_create_actor_from_pixeldata (resources->ps_Original,
-                                                      slice->matrix.x,
-                                                      slice->matrix.y,
+                                                      slice->matrix.i16_x,
+                                                      slice->matrix.i16_y,
                                                       (redraw_mode == REDRAW_ALL));
 
     clutter_actor_add_child (resources->c_Actor, c_BaseImage);
@@ -646,8 +646,8 @@ viewer_redraw (Viewer *resources, RedrawMode redraw_mode)
     /*------------------------------------------------------------------------.
      | APPLY PARENT SETTINGS                                                  |
      '------------------------------------------------------------------------*/
-    clutter_actor_set_width (resources->c_Actor, slice->matrix.x);
-    clutter_actor_set_height (resources->c_Actor, slice->matrix.y);
+    clutter_actor_set_width (resources->c_Actor, slice->matrix.i16_x);
+    clutter_actor_set_height (resources->c_Actor, slice->matrix.i16_y);
     clutter_actor_set_scale (resources->c_Actor,
                              slice->f_ScaleFactorX * resources->f_ZoomFactor,
                              slice->f_ScaleFactorY * resources->f_ZoomFactor);
@@ -660,8 +660,8 @@ viewer_redraw (Viewer *resources, RedrawMode redraw_mode)
   else
   {
     Slice *slice = PIXELDATA_ACTIVE_SLICE (resources->ps_Original);
-    clutter_actor_set_width (CLUTTER_ACTOR (resources->c_Actor), slice->matrix.x);
-    clutter_actor_set_height (CLUTTER_ACTOR (resources->c_Actor), slice->matrix.y);
+    clutter_actor_set_width (CLUTTER_ACTOR (resources->c_Actor), slice->matrix.i16_x);
+    clutter_actor_set_height (CLUTTER_ACTOR (resources->c_Actor), slice->matrix.i16_y);
     clutter_actor_set_scale (resources->c_Actor,
                              slice->f_ScaleFactorX * resources->f_ZoomFactor,
                              slice->f_ScaleFactorY * resources->f_ZoomFactor);
@@ -727,9 +727,9 @@ viewer_create_actor_from_pixeldata (PixelData *pixeldata, int width,
     if (!clutter_image_set_data (CLUTTER_IMAGE (mask_Content),
                                  (guint8 *)pixbuf,
                                  COGL_PIXEL_FORMAT_RGBA_8888,
-                                 slice->matrix.x,
-                                 slice->matrix.y,
-                                 (slice->matrix.x * 4),
+                                 slice->matrix.i16_x,
+                                 slice->matrix.i16_y,
+                                 (slice->matrix.i16_x * 4),
                                  &error))
     {
       debug_warning ("Could not load pixels to buffer: %s\n", error->message);
@@ -913,8 +913,8 @@ viewer_coordinate_within_image (Viewer *resources, Coordinate ts_Point)
 
   Slice *slice = VIEWER_ACTIVE_SLICE (resources);
   Plane ts_AbsolutePixelSize;
-  ts_AbsolutePixelSize.width = slice->matrix.x * slice->f_ScaleFactorX * resources->f_ZoomFactor;
-  ts_AbsolutePixelSize.height = slice->matrix.y * slice->f_ScaleFactorY * resources->f_ZoomFactor;
+  ts_AbsolutePixelSize.width = slice->matrix.i16_x * slice->f_ScaleFactorX * resources->f_ZoomFactor;
+  ts_AbsolutePixelSize.height = slice->matrix.i16_y * slice->f_ScaleFactorY * resources->f_ZoomFactor;
 
   Coordinate ts_ActorPosition;
   clutter_actor_get_position (resources->c_Actor, &ts_ActorPosition.x, &ts_ActorPosition.y);
@@ -1075,7 +1075,6 @@ viewer_on_mouse_move (UNUSED ClutterActor *actor, ClutterEvent *event, gpointer 
     resources->ts_PreviousMousePosition.x = ts_CurrentMousePosition.x;
     resources->ts_PreviousMousePosition.y = ts_CurrentMousePosition.y;
 
-    Serie *serie = resources->ps_ActiveLayer;
     PixelData *pixeldata = viewer_get_pixeldata_for_serie (resources, resources->ps_ActiveLayer);
 
     ts_WWWL.i32_windowWidth = (int)(ts_Diff.x);
@@ -1148,11 +1147,11 @@ viewer_on_leave_stage (UNUSED GtkWidget *widget, UNUSED GdkEvent *event, gpointe
 
   Slice *slice = VIEWER_ACTIVE_SLICE (resources);
   char *text = calloc (1, 110);
-  sprintf (text, "Slice:\t\t %-5.0f\n"
+  sprintf (text, "Slice:\t\t %d\n"
                  "Window/Level:\t %d / %d\n"
                  "Position:\nZoom:\nValue:\n"
                  "Macro:\t\t %s\n",
-                 slice->matrix.z,
+                 slice->matrix.i16_z,
                  pixeldata->ts_WWWL.i32_windowWidth, pixeldata->ts_WWWL.i32_windowLevel,
                  (resources->is_recording) ? "Recording" : "");
 
@@ -1235,11 +1234,11 @@ viewer_initialize (Viewer *resources, Serie *ts_Original, Serie *ts_Mask, List *
   assert (resources->ps_Original != NULL);
 
   // Set the default width and height.
-  resources->ts_OriginalPlane.width = slice->matrix.x;
-  resources->ts_OriginalPlane.height = slice->matrix.y;
+  resources->ts_OriginalPlane.width = slice->matrix.i16_x;
+  resources->ts_OriginalPlane.height = slice->matrix.i16_y;
 
-  resources->ts_ScaledPlane.width = slice->matrix.x * slice->f_ScaleFactorX;
-  resources->ts_ScaledPlane.height = slice->matrix.y * slice->f_ScaleFactorY;
+  resources->ts_ScaledPlane.width = slice->matrix.i16_x * slice->f_ScaleFactorX;
+  resources->ts_ScaledPlane.height = slice->matrix.i16_y * slice->f_ScaleFactorY;
 
   // Set up the display slice resources for the mask.
   viewer_add_mask_serie (resources, ts_Mask);
@@ -1264,8 +1263,8 @@ viewer_initialize (Viewer *resources, Serie *ts_Original, Serie *ts_Mask, List *
 
   assert (resources->c_Handles != NULL);
 
-  clutter_actor_set_width (resources->c_Actor, slice->matrix.x);
-  clutter_actor_set_height (resources->c_Actor, slice->matrix.y);
+  clutter_actor_set_width (resources->c_Actor, slice->matrix.i16_x);
+  clutter_actor_set_height (resources->c_Actor, slice->matrix.i16_y);
   clutter_actor_set_content_scaling_filters (resources->c_Actor, SCALING_FILTER, SCALING_FILTER);
 
   /*--------------------------------------------------------------------------.
@@ -1331,11 +1330,11 @@ viewer_new (Serie *ts_Original, Serie *ts_Mask, List *pll_Overlays,
   assert (resources->ps_Original != NULL);
 
   // Set the default width and height.
-  resources->ts_OriginalPlane.width = slice->matrix.x;
-  resources->ts_OriginalPlane.height = slice->matrix.y;
+  resources->ts_OriginalPlane.width = slice->matrix.i16_x;
+  resources->ts_OriginalPlane.height = slice->matrix.i16_y;
 
-  resources->ts_ScaledPlane.width = slice->matrix.x * slice->f_ScaleFactorX;
-  resources->ts_ScaledPlane.height = slice->matrix.y * slice->f_ScaleFactorY;
+  resources->ts_ScaledPlane.width = slice->matrix.i16_x * slice->f_ScaleFactorX;
+  resources->ts_ScaledPlane.height = slice->matrix.i16_y * slice->f_ScaleFactorY;
 
   // Set up the display slice resources for the mask.
   viewer_add_mask_serie (resources, ts_Mask);
@@ -1378,8 +1377,8 @@ viewer_new (Serie *ts_Original, Serie *ts_Mask, List *pll_Overlays,
   g_signal_connect (c_Canvas, "draw", G_CALLBACK (viewer_on_redraw_update_handles), resources);
 
   clutter_actor_set_background_color (resources->c_Stage, CLUTTER_COLOR_Black);
-  clutter_actor_set_width (resources->c_Actor, slice->matrix.x);
-  clutter_actor_set_height (resources->c_Actor, slice->matrix.y);
+  clutter_actor_set_width (resources->c_Actor, slice->matrix.i16_x);
+  clutter_actor_set_height (resources->c_Actor, slice->matrix.i16_y);
   clutter_actor_set_content_scaling_filters (resources->c_Actor, SCALING_FILTER, SCALING_FILTER);
 
   /*--------------------------------------------------------------------------.
@@ -1585,7 +1584,7 @@ viewer_set_active_mask_serie (Viewer *resources, Serie *serie)
 
   Slice *original_slice = PIXELDATA_ACTIVE_SLICE (resources->ps_Original);
   if (original_slice != NULL)
-    slice->matrix.z = original_slice->matrix.z;
+    slice->matrix.i16_z = original_slice->matrix.i16_z;
 
   if (resources->ps_ActiveMask == NULL)
   {

--- a/plugin/plugin-interface.c
+++ b/plugin/plugin-interface.c
@@ -18,17 +18,17 @@ CLM_Plugin_DrawPixelAtPoint (PixelData *ps_Mask, PixelData *ps_Selection,
 
   // Boundary checks.
   if (ts_Point.x < 0 || ts_Point.y < 0) return 0;
-  if (ts_Point.x + 1 > mask_slice->matrix.x || ts_Point.y >= mask_slice->matrix.y) return 0;
+  if (ts_Point.x + 1 > mask_slice->matrix.i16_x || ts_Point.y >= mask_slice->matrix.i16_y) return 0;
 
   void **ppv_SelectionDataCounter = NULL;
   if (ps_Selection != NULL)
   {
     ppv_SelectionDataCounter = PIXELDATA_ACTIVE_SLICE_DATA (ps_Selection);
-    ppv_SelectionDataCounter += (unsigned int)(ts_Point.y * mask_slice->matrix.x + ts_Point.x);
+    ppv_SelectionDataCounter += (unsigned int)(ts_Point.y * mask_slice->matrix.i16_x + ts_Point.x);
   }
 
   void **ppv_ImageDataCounter = PIXELDATA_ACTIVE_SLICE_DATA (ps_Mask);
-  ppv_ImageDataCounter += (unsigned int)(ts_Point.y * mask_slice->matrix.x + ts_Point.x);
+  ppv_ImageDataCounter += (unsigned int)(ts_Point.y * mask_slice->matrix.i16_x + ts_Point.x);
 
   switch (ps_Mask->serie->data_type)
   {
@@ -107,13 +107,13 @@ CLM_Plugin_GetPixelAtPoint (PixelData *ps_Layer, Coordinate ts_Point, void *pv_P
 
   // Boundary checks.
   if (ts_Point.x < 0 || ts_Point.y < 0) return 0;
-  if (ts_Point.x >= mask_slice->matrix.x || ts_Point.y >= mask_slice->matrix.y) return 0;
+  if (ts_Point.x >= mask_slice->matrix.i16_x || ts_Point.y >= mask_slice->matrix.i16_y) return 0;
 
   short int i16_Y = (short int)ts_Point.y;
   short int i16_X = (short int)ts_Point.x;
 
   void **ppv_ImageDataCounter = PIXELDATA_ACTIVE_SLICE_DATA (ps_Layer);
-  ppv_ImageDataCounter += (unsigned int)(i16_Y * mask_slice->matrix.x + i16_X);
+  ppv_ImageDataCounter += (unsigned int)(i16_Y * mask_slice->matrix.i16_x + i16_X);
 
   switch (ps_Layer->serie->data_type)
   {

--- a/plugin/src/brushes/libfill.c
+++ b/plugin/src/brushes/libfill.c
@@ -67,7 +67,7 @@ CLM_Plugin_Brush_Apply (UNUSED PixelData *ps_Original, PixelData *ps_Mask, Pixel
   Slice *mask_slice = PIXELDATA_ACTIVE_SLICE (ps_Mask);
   assert (mask_slice != NULL);
 
-  if (ts_Point.x > mask_slice->matrix.x || ts_Point.y > mask_slice->matrix.y) return;
+  if (ts_Point.x > mask_slice->matrix.i16_x || ts_Point.y > mask_slice->matrix.i16_y) return;
 
   int i32_CntArray;
   int i32_CntKernel;
@@ -76,8 +76,8 @@ CLM_Plugin_Brush_Apply (UNUSED PixelData *ps_Original, PixelData *ps_Mask, Pixel
 
   int i32_lengthArrayToRead = 1;
 
-  Coordinate *p_ArrayToReadFrom = calloc (1, PIXELDATA_ACTIVE_SLICE (ps_Original)->matrix.x *
-                                             PIXELDATA_ACTIVE_SLICE (ps_Original)->matrix.y *
+  Coordinate *p_ArrayToReadFrom = calloc (1, PIXELDATA_ACTIVE_SLICE (ps_Original)->matrix.i16_x *
+                                             PIXELDATA_ACTIVE_SLICE (ps_Original)->matrix.i16_y *
                                              sizeof (Coordinate));
   Coordinate *p_PointInArray = NULL;
 
@@ -110,8 +110,8 @@ CLM_Plugin_Brush_Apply (UNUSED PixelData *ps_Original, PixelData *ps_Mask, Pixel
     {
       ts_PixelPoint = ps_Kernel[i32_CntKernel];
 
-      if ((ts_PixelPoint.x >= 0) && (ts_PixelPoint.x < PIXELDATA_ACTIVE_SLICE (ps_Mask)->matrix.x) &&
-          (ts_PixelPoint.y >= 0) && (ts_PixelPoint.y < PIXELDATA_ACTIVE_SLICE (ps_Mask)->matrix.y))
+      if ((ts_PixelPoint.x >= 0) && (ts_PixelPoint.x < PIXELDATA_ACTIVE_SLICE (ps_Mask)->matrix.i16_x) &&
+          (ts_PixelPoint.y >= 0) && (ts_PixelPoint.y < PIXELDATA_ACTIVE_SLICE (ps_Mask)->matrix.i16_y))
       {
         if (CLM_Plugin_GetPixelAtPoint (ps_Mask, ts_PixelPoint, &i16_Value) && i16_Value == 0)
         {

--- a/plugin/src/brushes/libsobel.c
+++ b/plugin/src/brushes/libsobel.c
@@ -79,8 +79,8 @@ void v_PixelData_SobelEdgeDetection (PixelData *ps_Original, PixelData *ps_Mask,
   assert (slice != NULL);
 
   // Boundary check for a 10x10 local image.
-  if ((ts_Point.x > (slice->matrix.x - 5)) || (ts_Point.x < 5)
-      || (ts_Point.y > (slice->matrix.y - 5)) || (ts_Point.y < 5))
+  if ((ts_Point.x > (slice->matrix.i16_x - 5)) || (ts_Point.x < 5)
+      || (ts_Point.y > (slice->matrix.i16_y - 5)) || (ts_Point.y < 5))
   {
     return;
   }
@@ -121,8 +121,8 @@ v_PixelData_handleUINT8 (PixelData *ps_Original, PixelData *ps_Mask, PixelData *
   assert (slice != NULL);
 
   // Boundary check for a 10x10 local image.
-  if ((ts_Point.x > (slice->matrix.x - 5)) || (ts_Point.x < 5)
-      || (ts_Point.y > (slice->matrix.y - 5)) || (ts_Point.y < 5))
+  if ((ts_Point.x > (slice->matrix.i16_x - 5)) || (ts_Point.x < 5)
+      || (ts_Point.y > (slice->matrix.i16_y - 5)) || (ts_Point.y < 5))
   {
     return;
   }
@@ -326,8 +326,8 @@ v_PixelData_handleINT16 (PixelData *ps_Original, PixelData *ps_Mask, PixelData *
   assert (slice != NULL);
 
   // Boundary check for a 10x10 local image.
-  if ((ts_Point.x > (slice->matrix.x - 5)) || (ts_Point.x < 5)
-      || (ts_Point.y > (slice->matrix.y - 5)) || (ts_Point.y < 5))
+  if ((ts_Point.x > (slice->matrix.i16_x - 5)) || (ts_Point.x < 5)
+      || (ts_Point.y > (slice->matrix.i16_y - 5)) || (ts_Point.y < 5))
   {
     return;
   }
@@ -532,8 +532,8 @@ v_PixelData_handleFLOAT32 (PixelData *ps_Original, PixelData *ps_Mask, PixelData
   assert (slice != NULL);
 
   // Boundary check for a 10x10 local image.
-  if ((ts_Point.x > (slice->matrix.x - 5)) || (ts_Point.x < 5)
-      || (ts_Point.y > (slice->matrix.y - 5)) || (ts_Point.y < 5))
+  if ((ts_Point.x > (slice->matrix.i16_x - 5)) || (ts_Point.x < 5)
+      || (ts_Point.y > (slice->matrix.i16_y - 5)) || (ts_Point.y < 5))
   {
     return;
   }

--- a/plugin/src/selection-tools/librectangle.c
+++ b/plugin/src/selection-tools/librectangle.c
@@ -80,9 +80,9 @@ CLM_Plugin_Selection_Apply (UNUSED PixelData *ps_Original, PixelData *ps_Mask, P
     int i32_RowCount, i32_ColumnCount;
     Coordinate ts_Position;
 
-    for (i32_RowCount = 0; i32_RowCount < selection_slice->matrix.y; i32_RowCount++)
+    for (i32_RowCount = 0; i32_RowCount < selection_slice->matrix.i16_y; i32_RowCount++)
     {
-      for (i32_ColumnCount = 0; i32_ColumnCount < selection_slice->matrix.x; i32_ColumnCount++)
+      for (i32_ColumnCount = 0; i32_ColumnCount < selection_slice->matrix.i16_x; i32_ColumnCount++)
       {
         ts_Position.x = i32_ColumnCount;
         ts_Position.y = i32_RowCount;

--- a/source/gui/mainwindow.c
+++ b/source/gui/mainwindow.c
@@ -566,8 +566,8 @@ gui_mainwindow_save_undo_step (UNUSED GtkWidget *widget, UNUSED void *data)
   assert (ts_ActiveMask != NULL);
 
   unsigned long ul64_SerieSize;
-  ul64_SerieSize = ts_ActiveMask->matrix.x * ts_ActiveMask->matrix.y *
-    ts_ActiveMask->matrix.z * memory_serie_get_memory_space (ts_ActiveMask);
+  ul64_SerieSize = ts_ActiveMask->matrix.i16_x * ts_ActiveMask->matrix.i16_y *
+    ts_ActiveMask->matrix.i16_z * memory_serie_get_memory_space (ts_ActiveMask);
 
   pll_History = common_history_save_state (pll_History,
 					   ts_ActiveMask->data,
@@ -1166,17 +1166,17 @@ gui_mainwindow_update_viewer_positions (Viewer *viewer, void *data)
     switch (orientation)
     {
       case ORIENTATION_AXIAL:
-        i16_SliceNumber_Axial = slice->matrix.z;
+        i16_SliceNumber_Axial = slice->matrix.i16_z;
         i16_SliceNumber_Sagital = ts_Pivot.x - ts_Position->x;
         i16_SliceNumber_Coronal = ts_Pivot.y - ts_Position->y;
         break;
       case ORIENTATION_SAGITAL:
-        i16_SliceNumber_Sagital = slice->matrix.z;
+        i16_SliceNumber_Sagital = slice->matrix.i16_z;
         i16_SliceNumber_Axial =  ts_Pivot.z - ts_Position->y;
         i16_SliceNumber_Coronal =  ts_Pivot.x - ts_Position->x;
         break;
       case ORIENTATION_CORONAL:
-        i16_SliceNumber_Coronal = slice->matrix.z;
+        i16_SliceNumber_Coronal = slice->matrix.i16_z;
         i16_SliceNumber_Sagital = ts_Pivot.x - ts_Position->x;
         i16_SliceNumber_Axial = ts_Pivot.z - ts_Position->y;
         break;


### PR DESCRIPTION
- Images aren't displayed correct. There is a shift in pixels when displaying the file.
- It is implossible to draw at pixel [x,y] [0,0].

FIX: Partial redraw of slice data.

Changes:
- To achive a better redraw, floating point data pointers to the blob are excluded. Concrete, the filetype of the matrix has changed from float to short int. This affected the files:
- /lib/lib-io-dicom/lib-io-dicom.c
- /lib/lib-io-nifti/lib-io-nifti.c
- /lib/lib-viewer/lib-viewer.c
- /lib/lib-memory/lib-memory-slice.c
- /lib/lib-memory/lib-memory-serie.c
- /lib/lib-memory/lib-memory-io.c
- /lib/lib-pixeldata/lib-pixeldata.c
- /plugin/plugin-interface.c
- /plugin/src/selection-tools/librectangle.c
- /plugin/src/brushes/libsobel.c
- /plugin/src/brushes/libfill.c
- /source/gui/mainwindow.c
- New integer coordinate/vector type.
- /include/lib-common.h
- /include/lib-memory-serie.h
- /include/lib-memory-slice.h
- Removed unsused functions
- /include/lib-io-dicom.h
- Changed stride type from int to short int
- /include/lib-memory-slice.c
