### PR TITLE
Feature Change: OutOfBlobValue not drawable.

### DIFF
--- a/plugin/plugin-interface.c
+++ b/plugin/plugin-interface.c
@@ -30,6 +30,12 @@ CLM_Plugin_DrawPixelAtPoint (PixelData *ps_Mask, PixelData *ps_Selection,
   void **ppv_ImageDataCounter = PIXELDATA_ACTIVE_SLICE_DATA (ps_Mask);
   ppv_ImageDataCounter += (unsigned int)(ts_Point.y * mask_slice->matrix.i16_x + ts_Point.x);
 
+
+  if (*ppv_ImageDataCounter == mask_slice->serie->pv_OutOfBlobValue)
+  {
+    return 0;
+  }
+
   switch (ps_Mask->serie->data_type)
   {
   case MEMORY_TYPE_INT16:


### PR DESCRIPTION
FEATURE: It is possible to draw outside a blob. The OutOfBlobValue is then set to a value larger as 0. Please change this behaviour.

Change:
- /plugin/plugin-interface.c
  - built in check that verifies that the pointer to draw isn't equal with the pv_OutOfBlobValue pointer
