### PR TITLE
BUG FIX: Max value of LUT could not be used.

### DIFF
--- a/lib/lib-pixeldata/lib-pixeldata.c
+++ b/lib/lib-pixeldata/lib-pixeldata.c
@@ -346,7 +346,7 @@ pixeldata_apply_lookup_table (PixelData *pixeldata)
   }
 
   // Above maximum value.
-  for (counter = maximumWWWL; counter < range; counter++)
+  for (counter = maximumWWWL; counter <= range; counter++)
   {
     display_lookup_table[counter] = color_lookup_table[array_items - 1];
   }


### PR DESCRIPTION
BUG FIX: Max value of LUT could not be used.

FIX: Changed border check when applying LUT to slicedata

Change:
- lib/lib-pixeldata/lib-pixeldata.
  - Change condition from < to <= (for (counter = maximumWWWL; counter <= range; counter++))
