### PR TITLE
BUG: If loading an overlay, it is only accepted if the returned pointer is NULL.

### DIFF
--- a/source/gui/mainwindow.c
+++ b/source/gui/mainwindow.c
@@ -1845,7 +1845,7 @@ gui_mainwindow_overlay_add (UNUSED GtkWidget *widget, void *data)
 
     pt_Serie=pt_memory_io_load_file(&pt_Study,pc_path);
 
-    if (pt_Serie != NULL)
+    if (pt_Serie == NULL)
     {
       return FALSE;
     }


### PR DESCRIPTION
BUG: If loading an overlay, it is only accepted if the returned pointer is NULL. This causes a application crash.

FIX Changed this behavour

Changes:
- source/gui/mainwindow.c
  - changed condition from pt_Serie != NULL to pt_Serie ==
