### PR TITLE
BUGS: DICOM scanner space, mask offset

### DIFF
--- a/include/lib-memory-quaternion.h
+++ b/include/lib-memory-quaternion.h
@@ -66,6 +66,14 @@ typedef struct
 } td_Matrix4x4;
 
 /**
+ * Matrix definition (3x3).
+ */
+typedef struct
+{
+  double d_Matrix[3][3];
+} td_Matrix3x3;
+
+/**
  * Function that convert a quaternion with its offset to a rotation matrix.
  * @param[in]  ps_Source            Quaternion that should be converted.
  * @param[in]  ps_SourceOffset      Offset of quaternion in [i,j,k,w].
@@ -73,7 +81,9 @@ typedef struct
  * @param[in]  d_Qfac               Factor which defines stride Z-axis.
  * @param[out] matrix               A rotation matrix according to quaternion
  */
-td_Matrix4x4 tda_memory_quaternion_to_matrix(ts_Quaternion *ps_Source, ts_Quaternion *ps_SourceOffset, Coordinate3D *ps_pixel_dimension, double d_Qfac);
+td_Matrix4x4 tda_memory_quaternion_to_matrix(ts_Quaternion *ps_Source, ts_Quaternion *ps_SourceOffset, double d_Qfac);
+
+ts_Quaternion ts_memory_matrix_to_quaternion(td_Matrix4x4 *pt_Matrix, double * pd_Qfac);
 
 /**
  * Function that calculates a inverse of a 4x4 matrix.

--- a/lib/lib-io-dicom/lib-io-dicom.c
+++ b/lib/lib-io-dicom/lib-io-dicom.c
@@ -243,50 +243,28 @@ short int i16_memory_io_dicom_loadMetaData(Patient *ps_patient,
     }
     zz = zzclose(zz);
 
-    ps_serie->d_Qfac=1;
-    ps_serie->i16_QuaternionCode=1; //NIFTI_XFORM_SCANNER_ANAT
-
     ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[0][0] = -imageorientation[0];
     ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[0][1] = -imageorientation[3];
-    ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[0][2] = -(imageorientation[1] * imageorientation[5] -
-                                                      imageorientation[2] * imageorientation[4]);
-    ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[0][3] = -imageposvector[0];
+    ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[0][2] =  -(imageorientation[1] * imageorientation[5] -
+                                                        imageorientation[2] * imageorientation[4]);
+    ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[0][3] = 0;
 
     ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[1][0] = -imageorientation[1];
     ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[1][1] = -imageorientation[4];
-    ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[1][2] = -(imageorientation[2] * imageorientation[3] -
-                                                      imageorientation[0] * imageorientation[5]);
-    ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[1][3] = -imageposvector[1];
+    ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[1][2] =  -(imageorientation[2] * imageorientation[3] -
+                                                        imageorientation[0] * imageorientation[5]);
+    ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[1][3] = 0;
 
     ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[2][0] = imageorientation[2];
     ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[2][1] = imageorientation[5];
     ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[2][2] = (imageorientation[0] * imageorientation[4] -
-                                                      imageorientation[1] * imageorientation[3]);
-    ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[2][3] = imageposvector[2];
+                                                       imageorientation[1] * imageorientation[3]);
+    ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[2][3] = 0;
 
-    ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[3][0] = 0;
-    ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[3][1] = 0;
-    ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[3][2] = 0;
+    ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[3][0] = -imageposvector[0];
+    ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[3][1] = -imageposvector[1];
+    ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[3][2] = imageposvector[2];;
     ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[3][3] = 1;
-
-    ps_serie->t_ScannerSpaceXYZtoIJK = tda_memory_quaternion_inverse_matrix(&ps_serie->t_ScannerSpaceIJKtoXYZ);
-
-    ps_serie->pt_RotationMatrix = &ps_serie->t_ScannerSpaceIJKtoXYZ;
-    ps_serie->pt_InverseMatrix = &ps_serie->t_ScannerSpaceXYZtoIJK;
-
-    ps_serie->ps_Quaternion = calloc (1, sizeof (ts_Quaternion));
-
-    ps_serie->ps_QuaternationOffset = calloc (1, sizeof (ts_Quaternion));
-
-    // to be done, convert Sannerspace to quaternion
-
-    ps_serie->ps_QuaternationOffset->I = -(imageposvector[0]);
-    ps_serie->ps_QuaternationOffset->J = -(imageposvector[1]);
-    ps_serie->ps_QuaternationOffset->K =  (imageposvector[2]);
-
-    ps_serie->i16_StandardSpaceCode=0;
-    ps_serie->raw_data_type=MEMORY_TYPE_UINT16;
-    ps_serie->u8_AxisUnits=0;
 
     return 1;
   }

--- a/lib/lib-io-nifti/lib-io-nifti.c
+++ b/lib/lib-io-nifti/lib-io-nifti.c
@@ -690,6 +690,16 @@ memory_io_niftii_load (Serie *serie, const char *pc_Filename, const char *pc_Ima
       else if(serie->i16_QuaternionCode == NIFTI_XFORM_SCANNER_ANAT)
       {
         v_memory_io_handleSpace (serie);
+
+  Serie *ps_serie = serie;
+  printf("Translation matrix in scannerspace:\n");
+  printf("%10.2f, %10.2f, %10.2f, %10.2f \n", ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[0][0], ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[1][0], ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[2][0], ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[3][0]);
+  printf("%10.2f, %10.2f, %10.2f, %10.2f \n", ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[0][1], ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[1][1], ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[2][1], ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[3][1]);
+  printf("%10.2f, %10.2f, %10.2f, %10.2f \n", ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[0][2], ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[1][2], ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[2][2], ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[3][2]);
+  printf("%10.2f, %10.2f, %10.2f, %10.2f \n", ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[0][3], ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[1][3], ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[2][3], ps_serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[3][3]);
+  printf("\n");
+
+
         serie->pt_RotationMatrix = &serie->t_ScannerSpaceIJKtoXYZ;
         serie->pt_InverseMatrix = &serie->t_ScannerSpaceXYZtoIJK;
       }
@@ -761,6 +771,33 @@ memory_io_niftii_save (Serie *serie, const char *pc_File, const char *pc_ImageFi
 
   ps_Header->scl_slope = serie->slope;
   ps_Header->scl_inter = serie->offset;
+
+  ps_Header->qform_code = serie->i16_QuaternionCode;
+  ps_Header->quatern_b = serie->ps_Quaternion->I;
+  ps_Header->quatern_c = serie->ps_Quaternion->J;
+  ps_Header->quatern_d = serie->ps_Quaternion->K;
+
+  ps_Header->qoffset_x = serie->ps_QuaternationOffset->I;
+  ps_Header->qoffset_y = serie->ps_QuaternationOffset->J;
+  ps_Header->qoffset_z = serie->ps_QuaternationOffset->K;
+
+  ps_Header->sform_code = serie->i16_StandardSpaceCode;
+
+  ps_Header->srow_x[0] = serie->t_StandardSpaceIJKtoXYZ.d_Matrix[0][0];
+  ps_Header->srow_x[1] = serie->t_StandardSpaceIJKtoXYZ.d_Matrix[0][1];
+  ps_Header->srow_x[2] = serie->t_StandardSpaceIJKtoXYZ.d_Matrix[0][2];
+  ps_Header->srow_x[3] = serie->t_StandardSpaceIJKtoXYZ.d_Matrix[0][3];
+
+  ps_Header->srow_y[0] = serie->t_StandardSpaceIJKtoXYZ.d_Matrix[1][0];
+  ps_Header->srow_y[1] = serie->t_StandardSpaceIJKtoXYZ.d_Matrix[1][1];
+  ps_Header->srow_y[2] = serie->t_StandardSpaceIJKtoXYZ.d_Matrix[1][2];
+  ps_Header->srow_y[3] = serie->t_StandardSpaceIJKtoXYZ.d_Matrix[1][3];
+
+  ps_Header->srow_z[0] = serie->t_StandardSpaceIJKtoXYZ.d_Matrix[2][0];
+  ps_Header->srow_z[1] = serie->t_StandardSpaceIJKtoXYZ.d_Matrix[2][1];
+  ps_Header->srow_z[2] = serie->t_StandardSpaceIJKtoXYZ.d_Matrix[2][2];
+  ps_Header->srow_z[3] = serie->t_StandardSpaceIJKtoXYZ.d_Matrix[2][3];
+
 
   ps_Header->datatype = i16_NIFTII_ConvertMemoryDataTypeToNIFTII(serie->data_type);
   ps_Header->bitpix = i16_NIFTII_GetBitPix (serie->raw_data_type);

--- a/lib/lib-memory/lib-memory-quaternion.c
+++ b/lib/lib-memory/lib-memory-quaternion.c
@@ -29,39 +29,343 @@
 /*                                                                                                    */
 /*                                                                                                    */
 
+td_Matrix3x3 nifti_mat33_inverse( td_Matrix3x3 R )   /* inverse of 3x3 matrix */
+{
+   double r11,r12,r13,r21,r22,r23,r31,r32,r33 , deti ;
+   td_Matrix3x3 Q ;
+                                                       /*  INPUT MATRIX:  */
+   r11 = R.d_Matrix[0][0]; r12 = R.d_Matrix[0][1]; r13 = R.d_Matrix[0][2];  /* [ r11 r12 r13 ] */
+   r21 = R.d_Matrix[1][0]; r22 = R.d_Matrix[1][1]; r23 = R.d_Matrix[1][2];  /* [ r21 r22 r23 ] */
+   r31 = R.d_Matrix[2][0]; r32 = R.d_Matrix[2][1]; r33 = R.d_Matrix[2][2];  /* [ r31 r32 r33 ] */
+
+   deti = r11*r22*r33-r11*r32*r23-r21*r12*r33
+         +r21*r32*r13+r31*r12*r23-r31*r22*r13 ;
+
+   if( deti != 0.0l ) deti = 1.0l / deti ;
+
+   Q.d_Matrix[0][0] = deti*( r22*r33-r32*r23) ;
+   Q.d_Matrix[0][1] = deti*(-r12*r33+r32*r13) ;
+   Q.d_Matrix[0][2] = deti*( r12*r23-r22*r13) ;
+
+   Q.d_Matrix[1][0] = deti*(-r21*r33+r31*r23) ;
+   Q.d_Matrix[1][1] = deti*( r11*r33-r31*r13) ;
+   Q.d_Matrix[1][2] = deti*(-r11*r23+r21*r13) ;
+
+   Q.d_Matrix[2][0] = deti*( r21*r32-r31*r22) ;
+   Q.d_Matrix[2][1] = deti*(-r11*r32+r31*r12) ;
+   Q.d_Matrix[2][2] = deti*( r11*r22-r21*r12) ;
+
+   return Q ;
+}
+
+/*----------------------------------------------------------------------*/
+/*! compute the determinant of a 3x3 matrix
+*//*--------------------------------------------------------------------*/
+float nifti_mat33_determ( td_Matrix3x3 R )   /* determinant of 3x3 matrix */
+{
+   double r11,r12,r13,r21,r22,r23,r31,r32,r33 ;
+                                                       /*  INPUT MATRIX:  */
+   r11 = R.d_Matrix[0][0]; r12 = R.d_Matrix[0][1]; r13 = R.d_Matrix[0][2];  /* [ r11 r12 r13 ] */
+   r21 = R.d_Matrix[1][0]; r22 = R.d_Matrix[1][1]; r23 = R.d_Matrix[1][2];  /* [ r21 r22 r23 ] */
+   r31 = R.d_Matrix[2][0]; r32 = R.d_Matrix[2][1]; r33 = R.d_Matrix[2][2];  /* [ r31 r32 r33 ] */
+
+   return r11*r22*r33-r11*r32*r23-r21*r12*r33
+         +r21*r32*r13+r31*r12*r23-r31*r22*r13 ;
+}
+
+/*----------------------------------------------------------------------*/
+/*! compute the max row norm of a 3x3 matrix
+*//*--------------------------------------------------------------------*/
+float nifti_mat33_rownorm( td_Matrix3x3 A )  /* max row norm of 3x3 matrix */
+{
+   float r1,r2,r3 ;
+
+   r1 = fabs(A.d_Matrix[0][0])+fabs(A.d_Matrix[0][1])+fabs(A.d_Matrix[0][2]) ;
+   r2 = fabs(A.d_Matrix[1][0])+fabs(A.d_Matrix[1][1])+fabs(A.d_Matrix[1][2]) ;
+   r3 = fabs(A.d_Matrix[2][0])+fabs(A.d_Matrix[2][1])+fabs(A.d_Matrix[2][2]) ;
+   if( r1 < r2 ) r1 = r2 ;
+   if( r1 < r3 ) r1 = r3 ;
+   return r1 ;
+}
+
+/*----------------------------------------------------------------------*/
+/*! compute the max column norm of a 3x3 matrix
+*//*--------------------------------------------------------------------*/
+float nifti_mat33_colnorm( td_Matrix3x3 A )  /* max column norm of 3x3 matrix */
+{
+   float r1,r2,r3 ;
+
+   r1 = fabs(A.d_Matrix[0][0])+fabs(A.d_Matrix[1][0])+fabs(A.d_Matrix[2][0]) ;
+   r2 = fabs(A.d_Matrix[0][1])+fabs(A.d_Matrix[1][1])+fabs(A.d_Matrix[2][1]) ;
+   r3 = fabs(A.d_Matrix[0][2])+fabs(A.d_Matrix[1][2])+fabs(A.d_Matrix[2][2]) ;
+   if( r1 < r2 ) r1 = r2 ;
+   if( r1 < r3 ) r1 = r3 ;
+   return r1 ;
+}
+
+/*---------------------------------------------------------------------------*/
+/*! polar decomposition of a 3x3 matrix
+
+   This finds the closest orthogonal matrix to input A
+   (in both the Frobenius and L2 norms).
+
+   Algorithm is that from NJ Higham, SIAM J Sci Stat Comput, 7:1160-1174.
+*//*-------------------------------------------------------------------------*/
+td_Matrix3x3 nifti_mat33_polar( td_Matrix3x3 A )
+{
+   td_Matrix3x3 X , Y , Z ;
+   float alp,bet,gam,gmi , dif=1.0 ;
+   int k=0 ;
+
+   X = A ;
+
+   /* force matrix to be nonsingular */
+
+   gam = nifti_mat33_determ(X) ;
+   while( gam == 0.0 ){        /* perturb matrix */
+     gam = 0.00001 * ( 0.001 + nifti_mat33_rownorm(X) ) ;
+     X.d_Matrix[0][0] += gam ; X.d_Matrix[1][1] += gam ; X.d_Matrix[2][2] += gam ;
+     gam = nifti_mat33_determ(X) ;
+   }
+
+   while(1){
+     Y = nifti_mat33_inverse(X) ;
+     if( dif > 0.3 ){     /* far from convergence */
+       alp = sqrt( nifti_mat33_rownorm(X) * nifti_mat33_colnorm(X) ) ;
+       bet = sqrt( nifti_mat33_rownorm(Y) * nifti_mat33_colnorm(Y) ) ;
+       gam = sqrt( bet / alp ) ;
+       gmi = 1.0 / gam ;
+     } else {
+       gam = gmi = 1.0 ;  /* close to convergence */
+     }
+     Z.d_Matrix[0][0] = 0.5 * ( gam*X.d_Matrix[0][0] + gmi*Y.d_Matrix[0][0] ) ;
+     Z.d_Matrix[0][1] = 0.5 * ( gam*X.d_Matrix[0][1] + gmi*Y.d_Matrix[1][0] ) ;
+     Z.d_Matrix[0][2] = 0.5 * ( gam*X.d_Matrix[0][2] + gmi*Y.d_Matrix[2][0] ) ;
+     Z.d_Matrix[1][0] = 0.5 * ( gam*X.d_Matrix[1][0] + gmi*Y.d_Matrix[0][1] ) ;
+     Z.d_Matrix[1][1] = 0.5 * ( gam*X.d_Matrix[1][1] + gmi*Y.d_Matrix[1][1] ) ;
+     Z.d_Matrix[1][2] = 0.5 * ( gam*X.d_Matrix[1][2] + gmi*Y.d_Matrix[2][1] ) ;
+     Z.d_Matrix[2][0] = 0.5 * ( gam*X.d_Matrix[2][0] + gmi*Y.d_Matrix[0][2] ) ;
+     Z.d_Matrix[2][1] = 0.5 * ( gam*X.d_Matrix[2][1] + gmi*Y.d_Matrix[1][2] ) ;
+     Z.d_Matrix[2][2] = 0.5 * ( gam*X.d_Matrix[2][2] + gmi*Y.d_Matrix[2][2] ) ;
+
+     dif = fabs(Z.d_Matrix[0][0]-X.d_Matrix[0][0])+fabs(Z.d_Matrix[0][1]-X.d_Matrix[0][1])
+          +fabs(Z.d_Matrix[0][2]-X.d_Matrix[0][2])+fabs(Z.d_Matrix[1][0]-X.d_Matrix[1][0])
+          +fabs(Z.d_Matrix[1][1]-X.d_Matrix[1][1])+fabs(Z.d_Matrix[1][2]-X.d_Matrix[1][2])
+          +fabs(Z.d_Matrix[2][0]-X.d_Matrix[2][0])+fabs(Z.d_Matrix[2][1]-X.d_Matrix[2][1])
+          +fabs(Z.d_Matrix[2][2]-X.d_Matrix[2][2])                          ;
+
+     k = k+1 ;
+     if( k > 100 || dif < 3.e-6 ) break ;  /* convergence or exhaustion */
+     X = Z ;
+   }
+
+   return Z ;
+}
+
 
 /*                                                                                                    */
 /*                                                                                                    */
 /* GLOBAL FUNCTIONS                                                                                   */
 /*                                                                                                    */
 /*                                                                                                    */
-td_Matrix4x4 tda_memory_quaternion_to_matrix(ts_Quaternion *ps_Source, ts_Quaternion *ps_SourceOffset, Coordinate3D *ps_pixel_dimension, double d_Qfac)
+td_Matrix4x4 tda_memory_quaternion_to_matrix(ts_Quaternion *ps_Source, ts_Quaternion *ps_SourceOffset, double d_Qfac)
 {
   td_Matrix4x4 td_Rotation;
+  double d_Rotation;
 
-  td_Rotation.d_Matrix[3][0] = 0.0;
-  td_Rotation.d_Matrix[3][1] = 0.0;
-  td_Rotation.d_Matrix[3][2] = 0.0;
-  td_Rotation.d_Matrix[3][3] = 1.0;
+  d_Rotation = 1.0 - (ps_Source->I * ps_Source->I + ps_Source->J * ps_Source->J + ps_Source->K * ps_Source->K);
+
+  if (d_Rotation == 0 )
+  {
+    /* Special case according to niftii standard !?!*/
+    /* There should be a 180 degree rotation        */
+    d_Rotation = 1 / sqrt((ps_Source->I * ps_Source->I +  ps_Source->J * ps_Source->J +  ps_Source->K * ps_Source->K));
+    ps_Source->I *= d_Rotation;
+    ps_Source->J *= d_Rotation;
+    ps_Source->K *= d_Rotation;
+    ps_Source->W = 0;
+  }
+  else
+  {
+    ps_Source->W = sqrt(d_Rotation);
+  }
+
+  td_Rotation.d_Matrix[0][0] =     (ps_Source->W * ps_Source->W + ps_Source->I * ps_Source->I - ps_Source->J * ps_Source->J - ps_Source->K * ps_Source->K);
+  td_Rotation.d_Matrix[0][1] = 2 * (ps_Source->I * ps_Source->J + ps_Source->W * ps_Source->K);
+  td_Rotation.d_Matrix[0][2] = 2 * (ps_Source->I * ps_Source->K - ps_Source->W * ps_Source->J) * d_Qfac;
+
+  td_Rotation.d_Matrix[1][0] = 2 * (ps_Source->I * ps_Source->J - ps_Source->W * ps_Source->K);
+  td_Rotation.d_Matrix[1][1] =     (ps_Source->W * ps_Source->W - ps_Source->I * ps_Source->I + ps_Source->J * ps_Source->J - ps_Source->K * ps_Source->K);
+  td_Rotation.d_Matrix[1][2] = 2 * (ps_Source->J * ps_Source->K + ps_Source->W * ps_Source->I)* d_Qfac;
+
+  td_Rotation.d_Matrix[2][0] = 2 * (ps_Source->I * ps_Source->K + ps_Source->W * ps_Source->J);
+  td_Rotation.d_Matrix[2][1] = 2 * (ps_Source->J * ps_Source->K - ps_Source->W * ps_Source->I);
+  td_Rotation.d_Matrix[2][2] =     (ps_Source->W * ps_Source->W - ps_Source->I * ps_Source->I - ps_Source->J * ps_Source->J + ps_Source->K * ps_Source->K) * d_Qfac;
 
 
-  td_Rotation.d_Matrix[0][0] =     (ps_Source->W * ps_Source->W + ps_Source->I * ps_Source->I + ps_Source->J * ps_Source->J + ps_Source->K * ps_Source->K) * ps_pixel_dimension->x;
-  td_Rotation.d_Matrix[0][1] = 2 * (ps_Source->I * ps_Source->J - ps_Source->W * ps_Source->K) * ps_pixel_dimension->y;
-  td_Rotation.d_Matrix[0][2] = 2 * (ps_Source->I * ps_Source->K - ps_Source->W * ps_Source->J) * d_Qfac * ps_pixel_dimension->z;
-  td_Rotation.d_Matrix[0][3] = ps_SourceOffset->I;
+/*
+  td_Rotation.d_Matrix[0][0] =     (ps_Source->W * ps_Source->W + ps_Source->I * ps_Source->I - ps_Source->J * ps_Source->J - ps_Source->K * ps_Source->K);
+  td_Rotation.d_Matrix[0][1] = 2 * (ps_Source->I * ps_Source->J - ps_Source->W * ps_Source->K);
+  td_Rotation.d_Matrix[0][2] = 2 * (ps_Source->I * ps_Source->K + ps_Source->W * ps_Source->J);
 
-  td_Rotation.d_Matrix[1][0] = 2 * (ps_Source->I * ps_Source->J + ps_Source->W * ps_Source->K) * ps_pixel_dimension->x;
-  td_Rotation.d_Matrix[1][1] =     (ps_Source->W * ps_Source->W - ps_Source->I * ps_Source->I + ps_Source->J * ps_Source->J - ps_Source->K * ps_Source->K) * ps_pixel_dimension->y;
-  td_Rotation.d_Matrix[1][2] = 2 * (ps_Source->J * ps_Source->K - ps_Source->W * ps_Source->I) * ps_pixel_dimension->z * d_Qfac;
-  td_Rotation.d_Matrix[1][3] = ps_SourceOffset->J;
+  td_Rotation.d_Matrix[1][0] = 2 * (ps_Source->I * ps_Source->J + ps_Source->W * ps_Source->K);
+  td_Rotation.d_Matrix[1][1] =     (ps_Source->W * ps_Source->W - ps_Source->I * ps_Source->I + ps_Source->J * ps_Source->J - ps_Source->K * ps_Source->K);
+  td_Rotation.d_Matrix[1][2] = 2 * (ps_Source->J * ps_Source->K - ps_Source->W * ps_Source->I);
 
-  td_Rotation.d_Matrix[2][0] = 2 * (ps_Source->I * ps_Source->K - ps_Source->W * ps_Source->J) * ps_pixel_dimension->x;
-  td_Rotation.d_Matrix[2][1] = 2 * (ps_Source->J * ps_Source->K + ps_Source->W * ps_Source->I) * ps_pixel_dimension->y;
-  td_Rotation.d_Matrix[2][2] =     (ps_Source->W * ps_Source->W - ps_Source->I * ps_Source->I - ps_Source->J * ps_Source->J + ps_Source->K * ps_Source->K) * ps_pixel_dimension->z * d_Qfac;
-  td_Rotation.d_Matrix[2][3] = ps_SourceOffset->K;
+  td_Rotation.d_Matrix[2][0] = 2 * (ps_Source->I * ps_Source->K - ps_Source->W * ps_Source->J) * d_Qfac;
+  td_Rotation.d_Matrix[2][1] = 2 * (ps_Source->J * ps_Source->K + ps_Source->W * ps_Source->I)* d_Qfac;
+  td_Rotation.d_Matrix[2][2] =     (ps_Source->W * ps_Source->W - ps_Source->I * ps_Source->I - ps_Source->J * ps_Source->J + ps_Source->K * ps_Source->K) * d_Qfac;
+*/
+  td_Rotation.d_Matrix[3][0] = ps_SourceOffset->I;
+  td_Rotation.d_Matrix[3][1] = ps_SourceOffset->J;
+  td_Rotation.d_Matrix[3][2] = ps_SourceOffset->K;
+
+  td_Rotation.d_Matrix[0][3] = 0;
+  td_Rotation.d_Matrix[1][3] = 0;
+  td_Rotation.d_Matrix[2][3] = 0;
+  td_Rotation.d_Matrix[3][3] = 1;
+
 
   return td_Rotation;
 }
+
+ts_Quaternion ts_memory_matrix_to_quaternion(td_Matrix4x4 *pt_Matrix, double *pd_Qfac)
+{
+  ts_Quaternion ts_Quat;
+  double r11,r12,r13 , r21,r22,r23 , r31,r32,r33 ;
+
+  double xd,yd,zd , a,b,c,d ;
+
+  td_Matrix3x3 P,Q ;
+
+  /* [ r11 r12 r13 v1 ] */
+  /* [ r21 r22 r23 v2 ] */
+  /* [ r31 r32 r33 v3 ] */
+  /* [  0   0   0   1 ] */
+
+  /* load 3x3 matrix into local variables */
+
+  r11 = pt_Matrix->d_Matrix[0][0] ; r12 = pt_Matrix->d_Matrix[1][0] ; r13 = pt_Matrix->d_Matrix[2][0] ;
+  r21 = pt_Matrix->d_Matrix[0][1] ; r22 = pt_Matrix->d_Matrix[1][1] ; r23 = pt_Matrix->d_Matrix[2][1] ;
+  r31 = pt_Matrix->d_Matrix[0][2] ; r32 = pt_Matrix->d_Matrix[1][2] ; r33 = pt_Matrix->d_Matrix[2][2] ;
+
+  /* compute lengths of each column; these determine grid spacings  */
+
+  xd = sqrt( r11*r11 + r21*r21 + r31*r31 ) ;
+  yd = sqrt( r12*r12 + r22*r22 + r32*r32 ) ;
+  zd = sqrt( r13*r13 + r23*r23 + r33*r33 ) ;
+
+  /* if a column length is zero, patch the trouble */
+
+  if( xd == 0.0l ){ r11 = 1.0l ; r21 = r31 = 0.0l ; xd = 1.0l ; }
+  if( yd == 0.0l ){ r22 = 1.0l ; r12 = r32 = 0.0l ; yd = 1.0l ; }
+  if( zd == 0.0l ){ r33 = 1.0l ; r13 = r23 = 0.0l ; zd = 1.0l ; }
+
+   /* normalize the columns */
+
+   r11 /= xd ; r21 /= xd ; r31 /= xd ;
+   r12 /= yd ; r22 /= yd ; r32 /= yd ;
+   r13 /= zd ; r23 /= zd ; r33 /= zd ;
+
+   /* At this point, the matrix has normal columns, but we have to allow
+      for the fact that the hideous user may not have given us a matrix
+      with orthogonal columns.
+
+      So, now find the orthogonal matrix closest to the current matrix.
+
+      One reason for using the polar decomposition to get this
+      orthogonal matrix, rather than just directly orthogonalizing
+      the columns, is so that inputting the inverse matrix to R
+      will result in the inverse orthogonal matrix at this point.
+      If we just orthogonalized the columns, this wouldn't necessarily hold. */
+
+//   Q.d_Matrix[0][0] = r11 ; Q.d_Matrix[1][0] = r12 ; Q.d_Matrix[2][0] = r13 ; /* load Q */
+//   Q.d_Matrix[0][1] = r21 ; Q.d_Matrix[1][1] = r22 ; Q.d_Matrix[2][1] = r23 ;
+//   Q.d_Matrix[0][2] = r31 ; Q.d_Matrix[1][2] = r32 ; Q.d_Matrix[2][2] = r33 ;
+
+//   P = nifti_mat33_polar(Q) ;  /* P is orthog matrix closest to Q */
+
+//   r11 = P.d_Matrix[0][0] ; r12 = P.d_Matrix[1][0] ; r13 = P.d_Matrix[2][0] ; /* unload */
+//   r21 = P.d_Matrix[0][1] ; r22 = P.d_Matrix[1][1] ; r23 = P.d_Matrix[2][1] ;
+//   r31 = P.d_Matrix[0][2] ; r32 = P.d_Matrix[1][2] ; r33 = P.d_Matrix[2][2] ;
+
+   /*                            [ r11 r12 r13 ]               */
+   /* at this point, the matrix  [ r21 r22 r23 ] is orthogonal */
+   /*                            [ r31 r32 r33 ]               */
+
+   /* compute the determinant to determine if it is proper */
+
+   zd = r11*r22*r33-r11*r32*r23-r21*r12*r33
+       +r21*r32*r13+r31*r12*r23-r31*r22*r13 ;  /* should be -1 or 1 */
+
+   if( zd <= 0 )
+    {                  /* improper ==> flip 3rd column */
+      *pd_Qfac = -1;
+  //     ASSIF(qfac,-1.0) ;
+     r13 = -r13 ; r23 = -r23 ; r33 = -r33 ;
+   }
+   else
+   {
+     *pd_Qfac = 1;
+   }
+
+
+   /* now, compute quaternion parameters */
+
+  a = r11 + r22 + r33 + 1.0l ;
+
+  if( a > 0.5l )
+  {                /* simplest case */
+    a = 0.5l * sqrt(a) ;
+    b = 0.25l * (r32-r23) / a ;
+    c = 0.25l * (r13-r31) / a ;
+    d = 0.25l * (r21-r12) / a ;
+  }
+  else
+  {                       /* trickier case */
+    xd = 1.0 + r11 - (r22+r33) ;  /* 4*b*b */
+    yd = 1.0 + r22 - (r11+r33) ;  /* 4*c*c */
+    zd = 1.0 + r33 - (r11+r22) ;  /* 4*d*d */
+
+    if( xd > 1.0 )
+    {
+      b = 0.5l * sqrt(xd) ;
+      c = 0.25l* (r12+r21) / b ;
+      d = 0.25l* (r13+r31) / b ;
+      a = 0.25l* (r32-r23) / b ;
+    }
+    else if( yd > 1.0 )
+    {
+      c = 0.5l * sqrt(yd) ;
+      b = 0.25l* (r12+r21) / c ;
+      d = 0.25l* (r23+r32) / c ;
+      a = 0.25l* (r13-r31) / c ;
+    }
+    else
+    {
+      d = 0.5l * sqrt(zd) ;
+      b = 0.25l* (r13+r31) / d ;
+      c = 0.25l* (r23+r32) / d ;
+      a = 0.25l* (r21-r12) / d ;
+    }
+    if( a < 0.0l )
+    {
+      b=-b;
+      c=-c;
+      d=-d;
+      a=-a;
+    }
+  }
+
+  //   ASSIF(qb,b) ; ASSIF(qc,c) ; ASSIF(qd,d) ;
+  ts_Quat.W = a;
+  ts_Quat.I = b;
+  ts_Quat.J = c;
+  ts_Quat.K = d;
+
+  return ts_Quat;
+}
+
 
 td_Matrix4x4 tda_memory_quaternion_inverse_matrix(td_Matrix4x4 *ps_Matrix)
 {
@@ -75,43 +379,42 @@ td_Matrix4x4 tda_memory_quaternion_inverse_matrix(td_Matrix4x4 *ps_Matrix)
   /* [  0   0   0   1 ] */
 
   r11 = ps_Matrix->d_Matrix[0][0];
-  r12 = ps_Matrix->d_Matrix[0][1];
-  r13 = ps_Matrix->d_Matrix[0][2];
-  v1  = ps_Matrix->d_Matrix[0][3];
+  r12 = ps_Matrix->d_Matrix[1][0];
+  r13 = ps_Matrix->d_Matrix[2][0];
+  v1  = ps_Matrix->d_Matrix[3][0];
 
-  r21 = ps_Matrix->d_Matrix[1][0];
+  r21 = ps_Matrix->d_Matrix[0][1];
   r22 = ps_Matrix->d_Matrix[1][1];
-  r23 = ps_Matrix->d_Matrix[1][2];
-  v2  = ps_Matrix->d_Matrix[1][3];
+  r23 = ps_Matrix->d_Matrix[2][1];
+  v2  = ps_Matrix->d_Matrix[3][1];
 
-  r31 = ps_Matrix->d_Matrix[2][0];
-  r32 = ps_Matrix->d_Matrix[2][1];
+  r31 = ps_Matrix->d_Matrix[0][2];
+  r32 = ps_Matrix->d_Matrix[1][2];
   r33 = ps_Matrix->d_Matrix[2][2];
-  v3  = ps_Matrix->d_Matrix[2][3];
+  v3  = ps_Matrix->d_Matrix[3][2];
 
   d_Determinant = r11*r22*r33 - r11*r32*r23 - r21*r12*r33 + r21*r32*r13 + r31*r12*r23 - r31*r22*r13 ;
   d_Determinant = (d_Determinant == 0 ) ? d_Determinant : 1 / d_Determinant;
 
-  td_Inverse.d_Matrix[0][0] = d_Determinant ;
 
   td_Inverse.d_Matrix[0][0] = d_Determinant * ( r22*r33-r32*r23);
-  td_Inverse.d_Matrix[0][1] = d_Determinant * (-r12*r33+r32*r13);
-  td_Inverse.d_Matrix[0][2] = d_Determinant * ( r12*r23-r22*r13);
-  td_Inverse.d_Matrix[0][3] = d_Determinant * (-r12*r23*v3 + r12*v2*r33 + r22*r13*v3 - r22*v1*r33 - r32*r13*v2 + r32*v1*r23);
+  td_Inverse.d_Matrix[1][0] = d_Determinant * (-r12*r33+r32*r13);
+  td_Inverse.d_Matrix[2][0] = d_Determinant * ( r12*r23-r22*r13);
+  td_Inverse.d_Matrix[3][0] = d_Determinant * (-r12*r23*v3 + r12*v2*r33 + r22*r13*v3 - r22*v1*r33 - r32*r13*v2 + r32*v1*r23);
 
-  td_Inverse.d_Matrix[1][0] = d_Determinant * (-r21*r33+r31*r23);
+  td_Inverse.d_Matrix[0][1] = d_Determinant * (-r21*r33+r31*r23);
   td_Inverse.d_Matrix[1][1] = d_Determinant * ( r11*r33-r31*r13);
-  td_Inverse.d_Matrix[1][2] = d_Determinant * (-r11*r23+r21*r13);
-  td_Inverse.d_Matrix[1][3] = d_Determinant * ( r11*r23*v3 - r11*v2*r33 - r21*r13*v3 + r21*v1*r33 + r31*r13*v2 - r31*v1*r23);
+  td_Inverse.d_Matrix[2][1] = d_Determinant * (-r11*r23+r21*r13);
+  td_Inverse.d_Matrix[3][1] = d_Determinant * ( r11*r23*v3 - r11*v2*r33 - r21*r13*v3 + r21*v1*r33 + r31*r13*v2 - r31*v1*r23);
 
-  td_Inverse.d_Matrix[2][0] = d_Determinant * ( r21*r32-r31*r22);
-  td_Inverse.d_Matrix[2][1] = d_Determinant * (-r11*r32+r31*r12);
+  td_Inverse.d_Matrix[0][2] = d_Determinant * ( r21*r32-r31*r22);
+  td_Inverse.d_Matrix[1][2] = d_Determinant * (-r11*r32+r31*r12);
   td_Inverse.d_Matrix[2][2] = d_Determinant * ( r11*r22-r21*r12);
-  td_Inverse.d_Matrix[2][3] = d_Determinant * (-r11*r22*v3 + r11*r32*v2 + r21*r12*v3 - r21*r32*v1 - r31*r12*v2 + r31*r22*v1);
+  td_Inverse.d_Matrix[3][2] = d_Determinant * (-r11*r22*v3 + r11*r32*v2 + r21*r12*v3 - r21*r32*v1 - r31*r12*v2 + r31*r22*v1);
 
-  td_Inverse.d_Matrix[3][0] = 0;
-  td_Inverse.d_Matrix[3][1] = 0;
-  td_Inverse.d_Matrix[3][2] = 0;
+  td_Inverse.d_Matrix[0][3] = 0;
+  td_Inverse.d_Matrix[1][3] = 0;
+  td_Inverse.d_Matrix[2][3] = 0;
   td_Inverse.d_Matrix[3][3] = (d_Determinant == 0) ? 0 : 1 ;
 
   return td_Inverse;

--- a/lib/lib-memory/lib-memory-serie.c
+++ b/lib/lib-memory/lib-memory-serie.c
@@ -317,23 +317,23 @@ memory_serie_create_mask_from_serie (Serie *serie)
          (mask->i16_QuaternionCode == NIFTI_XFORM_UNKNOWN))
   {
     mask->t_StandardSpaceIJKtoXYZ.d_Matrix[0][0]=1;
-    mask->t_StandardSpaceIJKtoXYZ.d_Matrix[0][1]=0;
-    mask->t_StandardSpaceIJKtoXYZ.d_Matrix[0][2]=0;
-    mask->t_StandardSpaceIJKtoXYZ.d_Matrix[0][3]=0;
-
     mask->t_StandardSpaceIJKtoXYZ.d_Matrix[1][0]=0;
-    mask->t_StandardSpaceIJKtoXYZ.d_Matrix[1][1]=1;
-    mask->t_StandardSpaceIJKtoXYZ.d_Matrix[1][2]=0;
-    mask->t_StandardSpaceIJKtoXYZ.d_Matrix[1][3]=0;
-
     mask->t_StandardSpaceIJKtoXYZ.d_Matrix[2][0]=0;
-    mask->t_StandardSpaceIJKtoXYZ.d_Matrix[2][1]=0;
-    mask->t_StandardSpaceIJKtoXYZ.d_Matrix[2][2]=1;
-    mask->t_StandardSpaceIJKtoXYZ.d_Matrix[2][3]=0;
-
     mask->t_StandardSpaceIJKtoXYZ.d_Matrix[3][0]=0;
+
+    mask->t_StandardSpaceIJKtoXYZ.d_Matrix[0][1]=0;
+    mask->t_StandardSpaceIJKtoXYZ.d_Matrix[1][1]=1;
+    mask->t_StandardSpaceIJKtoXYZ.d_Matrix[2][1]=0;
     mask->t_StandardSpaceIJKtoXYZ.d_Matrix[3][1]=0;
+
+    mask->t_StandardSpaceIJKtoXYZ.d_Matrix[0][2]=0;
+    mask->t_StandardSpaceIJKtoXYZ.d_Matrix[1][2]=0;
+    mask->t_StandardSpaceIJKtoXYZ.d_Matrix[2][2]=1;
     mask->t_StandardSpaceIJKtoXYZ.d_Matrix[3][2]=0;
+
+    mask->t_StandardSpaceIJKtoXYZ.d_Matrix[0][3]=0;
+    mask->t_StandardSpaceIJKtoXYZ.d_Matrix[1][3]=0;
+    mask->t_StandardSpaceIJKtoXYZ.d_Matrix[2][3]=0;
     mask->t_StandardSpaceIJKtoXYZ.d_Matrix[3][3]=1;
 
     mask->t_StandardSpaceXYZtoIJK = tda_memory_quaternion_inverse_matrix(&mask->t_StandardSpaceIJKtoXYZ);
@@ -430,19 +430,19 @@ v_memory_io_handleSpace (Serie *serie)
 
   if (serie->i16_QuaternionCode == NIFTI_XFORM_UNKNOWN)
   {
-    serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[0][0] = serie->pixel_dimension.x;
+    serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[0][0] = 1;
     serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[0][1] = 0;
     serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[0][2] = 0;
     serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[0][3] = 0;
 
     serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[1][0] = 0;
-    serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[1][1] = serie->pixel_dimension.y;
+    serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[1][1] = 1;
     serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[1][2] = 0;
-    serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[2][3] = 0;
+    serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[1][3] = 0;
 
     serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[2][0] = 0;
     serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[2][1] = 0;
-    serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[2][2] = serie->pixel_dimension.z;
+    serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[2][2] = 1;
     serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[2][3] = 0;
 
     serie->t_ScannerSpaceIJKtoXYZ.d_Matrix[3][0] = 0;
@@ -454,28 +454,7 @@ v_memory_io_handleSpace (Serie *serie)
   }
   else if (serie->i16_QuaternionCode == NIFTI_XFORM_SCANNER_ANAT)
   {
-    d_Rotation = 1.0 - (serie->ps_Quaternion->I * serie->ps_Quaternion->I +
-                        serie->ps_Quaternion->J * serie->ps_Quaternion->J +
-                        serie->ps_Quaternion->K * serie->ps_Quaternion->K);
-
-    if (d_Rotation == 0 )
-    {
-      /* Special case according to niftii standard !?!*/
-      /* There should be a 180 degree rotation        */
-      d_Rotation = 1 / sqrt((serie->ps_Quaternion->I * serie->ps_Quaternion->I +
-                                          serie->ps_Quaternion->J * serie->ps_Quaternion->J +
-                                          serie->ps_Quaternion->K * serie->ps_Quaternion->K));
-      serie->ps_Quaternion->I *= d_Rotation;
-      serie->ps_Quaternion->J *= d_Rotation;
-      serie->ps_Quaternion->K *= d_Rotation;
-      serie->ps_Quaternion->W = 0;
-    }
-    else
-    {
-      serie->ps_Quaternion->W = sqrt(d_Rotation);
-    }
-
-    serie->t_ScannerSpaceIJKtoXYZ = tda_memory_quaternion_to_matrix(serie->ps_Quaternion, serie->ps_QuaternationOffset, &serie->pixel_dimension, serie->d_Qfac);
+    serie->t_ScannerSpaceIJKtoXYZ = tda_memory_quaternion_to_matrix(serie->ps_Quaternion, serie->ps_QuaternationOffset, serie->d_Qfac);
     serie->t_ScannerSpaceXYZtoIJK = tda_memory_quaternion_inverse_matrix(&serie->t_ScannerSpaceIJKtoXYZ);
   }
 

--- a/plugin/src/brushes/libsobel.c
+++ b/plugin/src/brushes/libsobel.c
@@ -21,6 +21,8 @@
 void v_PixelData_handleUINT8 (PixelData *ps_Original, PixelData *ps_Mask, PixelData *ps_Selection,
                               Coordinate ts_Point, unsigned char ui32_DrawValue, PixelAction te_Action);
 
+void v_PixelData_handleUINT16 (PixelData *ps_Original, PixelData *ps_Mask, PixelData *ps_Selection,
+                              Coordinate ts_Point, unsigned char ui32_DrawValue, PixelAction te_Action);
 void v_PixelData_handleINT16 (PixelData *ps_Original, PixelData *ps_Mask, PixelData *ps_Selection,
                               Coordinate ts_Point, unsigned char ui32_DrawValue, PixelAction te_Action);
 


### PR DESCRIPTION
BUGS:
- DICOM scanner space isn't calculated to proper quaternion.
- There is a offset in the image of 1 by 1 pixel. This causes a wrong
  mask.

FIX:
- DICOM scanner space bug is temporary solved. Clmedview could save and
  load images with a "proper qaternion" in a way that the
  geometrical positioning is write.
- The offset is solved!

Changes:
- /include/lib-memory-quaternion.h
- /lib/lib-io-dicom/lib-io-dicom.c
- /lib/lib-io-nifti/lib-io-nifti.c
- /lib/lib-memory/lib-memory-io.c
- /lib/lib-memory/lib-memory-quaternion.c
- /lib/lib-memory/lib-memory-serie.c
- /plugin/src/brushes/libsobel.c
