### PR TITLE
CODE CLEANUP: Gather all code regarding algebraic functions into 1 library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,9 +21,9 @@ SUBDIRS                 = . plugin
 ACLOCAL_AMFLAGS         = -I m4
 AUTOMAKE_OPTIONS 	= subdir-objects
 AM_CFLAGS 		= $(gtk_CFLAGS) $(glib_CFLAGS) $(zlib_CFLAGS) \
-                $(clutter_CFLAGS) \
-                $(cluttergtk_CFLAGS) $(uuid_CFLAGS) -Iinclude/ \
-                -Ilib/lib-common/include/ -Iplugin/
+                          $(clutter_CFLAGS) \
+                          $(cluttergtk_CFLAGS) $(uuid_CFLAGS) -Iinclude/ \
+                         -Ilib/lib-common/include/ -Iplugin/
 
 bin_PROGRAMS 		= clmedview
 
@@ -40,12 +40,12 @@ INCLUDE_SOURCES 	= include/lib-pixeldata.h \
 			  include/lib-memory-study.h \
 			  include/lib-memory-serie.h \
 			  include/lib-memory-slice.h \
-			  include/lib-memory-quaternion.h \
 			  include/lib-memory-tree.h \
 			  include/lib-common-list.h \
 			  include/lib-common-tree.h \
 			  include/lib-common-debug.h \
 			  include/lib-common-unused.h \
+			  include/lib-common-algebra.h \
 			  include/lib-configuration.h
 
 PLUGIN_FILES		= plugin/Makefile.am \
@@ -77,19 +77,19 @@ LIB_IO_DICOM_SOURCES    = lib/lib-io-dicom/lib-io-dicom.c \
 
 
 
-LIB_IO_NIFTI_SOURCES = lib/lib-io-nifti/lib-io-nifti.c
+LIB_IO_NIFTI_SOURCES    = lib/lib-io-nifti/lib-io-nifti.c
 
 LIB_MEMORY_SOURCES	= lib/lib-memory/lib-memory-tree.c \
 			  lib/lib-memory/lib-memory-patient.c \
 			  lib/lib-memory/lib-memory-study.c \
 			  lib/lib-memory/lib-memory-serie.c \
 			  lib/lib-memory/lib-memory-slice.c \
-			  lib/lib-memory/lib-memory-quaternion.c \
 			  lib/lib-memory/lib-memory-io.c
 
 LIB_COMMON_SOURCES	= lib/lib-common/lib-common-list.c \
 			  lib/lib-common/lib-common-tree.c \
 			  lib/lib-common/lib-common-history.c \
+			  lib/lib-common/lib-common-algebra.c \
 			  lib/lib-common/lib-common-debug.c
 
 LIB_PIXELDATA_SOURCES	= lib/lib-pixeldata/lib-pixeldata.c \

--- a/include/lib-common-algebra.h
+++ b/include/lib-common-algebra.h
@@ -17,8 +17,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MEMORY_QUATERNION_H
-#define MEMORY_QUATERNION_H
+#ifndef COMMON_ALGEBRA_H
+#define COMMON_ALGEBRA_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -111,4 +111,4 @@ Vector3D ts_memory_matrix_multiply4x4(td_Matrix4x4 *ps_Matrix, Vector3D *ps_Vect
 }
 #endif
 
-#endif//MEMORY_QUATERNION_H
+#endif//COMMON_ALGEBRA_H

--- a/include/lib-io-nifti.h
+++ b/include/lib-io-nifti.h
@@ -26,7 +26,7 @@
 #include "lib/lib-io-nifti/include/nifti1.h"
 #include "lib-memory.h"
 #include "lib-memory-serie.h"
-#include "lib-memory-quaternion.h"
+#include "lib-common-algebra.h"
 
 
 #define MIN_HEADER_SIZE 348

--- a/include/lib-memory-serie.h
+++ b/include/lib-memory-serie.h
@@ -28,7 +28,7 @@ extern "C" {
 #include "lib-common.h"
 #include "lib-common-list.h"
 #include "lib-memory.h"
-#include "lib-memory-quaternion.h"
+#include "lib-common-algebra.h"
 
 #define COORDINATES_UNKNOWN      0  /*! Arbitrary coordinates (Method 1). */
 #define COORDINATES_SCANNER_ANAT 1  /*! Scanner-based anatomical coordinates */

--- a/lib/lib-common/lib-common-algebra.c
+++ b/lib/lib-common/lib-common-algebra.c
@@ -17,7 +17,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "lib-memory-quaternion.h"
+#include "lib-common-algebra.h"
 #include "lib-common-debug.h"
 
 #include <stdlib.h>

--- a/lib/lib-memory/lib-memory-slice.c
+++ b/lib/lib-memory/lib-memory-slice.c
@@ -20,7 +20,7 @@
 #include "lib-memory-slice.h"
 #include "lib-memory-serie.h"
 #include "lib-common-debug.h"
-#include "lib-memory-quaternion.h"
+#include "lib-common-algebra.h"
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
CODE CLEANUP: Gather all code regarding algebraic functions into 1 library

CHANGES:
- moved lib/lib-memory/lib-memory-quaternion.c to lib/lib-common/lib-common-algebra.c
- moved lib/lib-memory/lib-memory-quaternion.h to lib/lib-common/lib-common-algebra.h
- Changed lib-memory-quaternion into lib-common-algebra. This affected:
  - include/lib-io-nifti.h
  - include/lib-memory-serie.h
  - include/lib-memory-quaternion.h
  - lib/lib-memory/lib-memory-io.c
  - lib/lib-memory/lib-memory-quaternion.c
  - lib/lib-memory/lib-memory-slice.c
