### PR TITLE
Bug fix: Dicom orientation not correct transformed to quaternion.

### DIFF
--- a/include/lib-common-algebra.h
+++ b/include/lib-common-algebra.h
@@ -47,6 +47,15 @@ extern "C" {
 
 
 /**
+ * Macro to load a 4x4 matrix
+ */
+#define LOAD_MAT44(AA,a11,a12,a13,a14 ,a21,a22,a23,a24 ,a31,a32,a33,a34, a41,a42,a43,a44)    \
+( AA.af_Matrix[0][0]=a11, AA.af_Matrix[1][0]=a12, AA.af_Matrix[2][0]=a13, AA.af_Matrix[3][0]=a14 ,   \
+  AA.af_Matrix[0][1]=a21, AA.af_Matrix[1][1]=a22, AA.af_Matrix[2][1]=a23, AA.af_Matrix[3][1]=a24  ,   \
+  AA.af_Matrix[0][2]=a31, AA.af_Matrix[1][2]=a32, AA.af_Matrix[2][2]=a33, AA.af_Matrix[3][2]=a34 , \
+  AA.af_Matrix[0][3]=a41, AA.af_Matrix[1][3]=a42, AA.af_Matrix[2][3]=a43, AA.af_Matrix[3][3]=a44 )
+
+/**
  * Quaternion definition.
  */
 typedef struct
@@ -63,7 +72,7 @@ typedef struct
 typedef struct
 {
   float af_Matrix[4][4];
-} td_Matrix4x4;
+} ts_Matrix4x4;
 
 /**
  * Matrix definition (3x3).
@@ -71,7 +80,8 @@ typedef struct
 typedef struct
 {
   double af_Matrix[3][3];
-} td_Matrix3x3;
+} ts_Matrix3x3;
+
 
 
 
@@ -104,7 +114,7 @@ Vector3D s_algebra_vector_crossproduct(Vector3D *ps_InputVector,Vector3D *pts_pe
  * @param[in]  ps_Vector  Vector to transform.
  * @param[out] vector     Transformed vector.
  */
-Vector3D ts_algebra_vector_translate(td_Matrix4x4 *ps_Matrix, Vector3D *ps_Vector);
+Vector3D ts_algebra_vector_translate(ts_Matrix4x4 *ps_Matrix, Vector3D *ps_Vector);
 
 /**
  * Function that calculates the maximum of a vector.
@@ -167,14 +177,22 @@ Vector3D ts_algebra_vector_Rotation_around_Z_Axis (Vector3D *ps_Vector, float f_
  * @param[in]  d_Qfac               Factor which defines stride Z-axis.
  * @param[out] matrix               A rotation matrix according to quaternion
  */
-td_Matrix4x4 tda_algebra_matrix_QuaternionToMatrix(ts_Quaternion *ps_Source, ts_Quaternion *ps_SourceOffset, double d_Qfac);
+ts_Matrix4x4 tda_algebra_matrix_4x4_QuaternionToMatrix(ts_Quaternion *ps_Source, ts_Quaternion *ps_SourceOffset, double d_Qfac);
 
 /**
  * Function that calculates a inverse of a 4x4 matrix.
  * @param[in]  ps_Matrix  Input matrix.
  * @param[out] matrix     Output matrix.
  */
-td_Matrix4x4 tda_algebra_matrix_inverse(td_Matrix4x4 *ps_Matrix);
+ts_Matrix4x4 tda_algebra_matrix_4x4_inverse(ts_Matrix4x4 *ps_Matrix);
+
+/**
+ * Function that multiplys a 4x4 matrix.
+ * @param[in]  ps_MatrixA  Input matrix.
+ * @param[in]  ps_MatrixB  Input matrix.
+ * @param[out] matrix      Output matrix.
+ */
+ts_Matrix4x4 tda_algebra_matrix_4x4_multiply(ts_Matrix4x4 *ps_MatrixA , ts_Matrix4x4 *ps_MatrixB);
 
 /**
  * Function that convert a matrix to a quaternion
@@ -182,7 +200,7 @@ td_Matrix4x4 tda_algebra_matrix_inverse(td_Matrix4x4 *ps_Matrix);
  * @param[in]  d_Qfac               Factor which defines stride Z-axis.
  * @param[out] quaternion        A rotation matrix according to quaternion
  */
-ts_Quaternion ts_algebra_quaternion_MatrixToQuaternion(td_Matrix4x4 *pt_Matrix, double *pd_Qfac);
+ts_Quaternion ts_algebra_quaternion_MatrixToQuaternion(ts_Matrix4x4 *pt_Matrix, double *pd_Qfac);
 
 
 #ifdef __cplusplus

--- a/include/lib-io-dicom.h
+++ b/include/lib-io-dicom.h
@@ -55,7 +55,7 @@ typedef enum
  */
 short int i16_memory_io_dicom_relativePosition(Coordinate3D *ps_referencePosition,
                                                Coordinate3D *ps_position,
-                                               td_Matrix4x4 *pt_rotationMatrix,
+                                               Vector3D     *ps_Zvector,
                                                Coordinate3D *ps_pixel_dimension);
 
 /**
@@ -72,6 +72,8 @@ short int i16_memory_io_dicom_loadMetaData(Patient *ps_patient,
                                            Study *ps_study,
                                            Serie *ps_serie,
                                            Coordinate3D *ps_SlicePosition,
+                                           Vector3D  *ps_XVector,
+                                           Vector3D  *ps_YVector,
                                            short int *pi16_TemporalPositionIdentifier,
                                            short int *pi16_StackPositionIdentifier,
                                            te_DCM_ComplexImageComponent *pe_DCM_CIC,

--- a/include/lib-memory-serie.h
+++ b/include/lib-memory-serie.h
@@ -190,13 +190,13 @@ typedef struct
   * Rotation matrix of scanner space.
   * It defines the translation from IJK space to XYZ
   */
-  td_Matrix4x4 t_ScannerSpaceIJKtoXYZ;
+  ts_Matrix4x4 t_ScannerSpaceIJKtoXYZ;
 
   /**
   * Inverse rotation matrix of scanner space.
   * It defines the translation from XYZ space to IJK
   */
-  td_Matrix4x4 t_ScannerSpaceXYZtoIJK;
+  ts_Matrix4x4 t_ScannerSpaceXYZtoIJK;
 
   /**
   * Standard space code which defined the type of space
@@ -207,24 +207,24 @@ typedef struct
   * Rotation matrix of scanner space.
   * It defines the translation from IJK space to XYZ
   */
-  td_Matrix4x4 t_StandardSpaceIJKtoXYZ;
+  ts_Matrix4x4 t_StandardSpaceIJKtoXYZ;
 
   /**
   * Inverse rotation matrix of scanner space.
   * It defines the translation from XYZ space to IJK
   */
-  td_Matrix4x4 t_StandardSpaceXYZtoIJK;
+  ts_Matrix4x4 t_StandardSpaceXYZtoIJK;
 
 
   /**
   * Pointer to selected rotation matrices
   */
-  td_Matrix4x4 *pt_RotationMatrix;
+  ts_Matrix4x4 *pt_RotationMatrix;
 
   /**
   * Pointer to selected inverse rotation matrices
   */
-  td_Matrix4x4 *pt_InverseMatrix;
+  ts_Matrix4x4 *pt_InverseMatrix;
 
   /**
   * Minimum value in serie.

--- a/lib/lib-io-dicom/lib-io-dicom.c
+++ b/lib/lib-io-dicom/lib-io-dicom.c
@@ -37,26 +37,26 @@
 /*                                                                                                    */
 short int i16_memory_io_dicom_relativePosition(Coordinate3D *ps_referencePosition,
                                                Coordinate3D *ps_position,
-                                               td_Matrix4x4 *pt_rotationMatrix,
+                                               Vector3D     *ps_Zvector,
                                                Coordinate3D *ps_pixel_dimension)
 {
   Coordinate3D s_Delta;
-  Vector3D z_Vector;
   Vector3D relativeVector;
 
   s_Delta.z = ps_position->z - ps_referencePosition->z;
 
-  z_Vector.z = pt_rotationMatrix->af_Matrix[2][2];
-
-  relativeVector.z = s_Delta.z / (z_Vector.z * ps_pixel_dimension->z);
+  relativeVector.z = s_Delta.z / (ps_Zvector->z * ps_pixel_dimension->z);
 
   return round(relativeVector.z);
 }
+
 
 short int i16_memory_io_dicom_loadMetaData(Patient *ps_patient,
                                            Study *ps_study,
                                            Serie *ps_serie,
                                            Coordinate3D *ps_SlicePosition,
+                                           Vector3D  *ps_XVector,
+                                           Vector3D  *ps_YVector,
                                            short int *pi16_TemporalPositionIdentifier,
                                            short int *pi16_StackPositionIdentifier,
                                            te_DCM_ComplexImageComponent *pe_DCM_CIC,
@@ -179,6 +179,12 @@ short int i16_memory_io_dicom_loadMetaData(Patient *ps_patient,
           break;
         case DCM_ImageOrientationPatient:	// DS, 6 values
           zzrDS(zz, 6, imageorientation);
+          ps_XVector->x = imageorientation[0];
+          ps_XVector->y = imageorientation[1];
+          ps_XVector->z = imageorientation[2];
+          ps_YVector->x = imageorientation[3];
+          ps_YVector->y = imageorientation[4];
+          ps_YVector->z = imageorientation[5];
           break;
         case DCM_RescaleIntercept:	// DS, the b in m*SV + b
           zzgetstring(zz, value, sizeof(value) - 1);

--- a/lib/lib-io-nifti/lib-io-nifti.c
+++ b/lib/lib-io-nifti/lib-io-nifti.c
@@ -674,7 +674,7 @@ memory_io_niftii_load (Serie *serie, const char *pc_Filename, const char *pc_Ima
         serie->t_StandardSpaceIJKtoXYZ.af_Matrix[3][2]=0;
         serie->t_StandardSpaceIJKtoXYZ.af_Matrix[3][3]=1;
 
-        serie->t_StandardSpaceXYZtoIJK = tda_algebra_matrix_inverse(&serie->t_StandardSpaceIJKtoXYZ);
+        serie->t_StandardSpaceXYZtoIJK = tda_algebra_matrix_4x4_inverse(&serie->t_StandardSpaceIJKtoXYZ);
 
         serie->pt_RotationMatrix = &serie->t_StandardSpaceIJKtoXYZ;
         serie->pt_InverseMatrix = &serie->t_StandardSpaceXYZtoIJK;
@@ -683,7 +683,7 @@ memory_io_niftii_load (Serie *serie, const char *pc_Filename, const char *pc_Ima
               (serie->i16_StandardSpaceCode == NIFTI_XFORM_TALAIRACH) ||
               (serie->i16_StandardSpaceCode == NIFTI_XFORM_MNI_152))
       {
-        serie->t_StandardSpaceXYZtoIJK = tda_algebra_matrix_inverse(&serie->t_StandardSpaceIJKtoXYZ);
+        serie->t_StandardSpaceXYZtoIJK = tda_algebra_matrix_4x4_inverse(&serie->t_StandardSpaceIJKtoXYZ);
         serie->pt_RotationMatrix = &serie->t_StandardSpaceIJKtoXYZ;
         serie->pt_InverseMatrix = &serie->t_StandardSpaceXYZtoIJK;
       }

--- a/lib/lib-memory/lib-memory-serie.c
+++ b/lib/lib-memory/lib-memory-serie.c
@@ -336,7 +336,7 @@ memory_serie_create_mask_from_serie (Serie *serie)
     mask->t_StandardSpaceIJKtoXYZ.af_Matrix[2][3]=0;
     mask->t_StandardSpaceIJKtoXYZ.af_Matrix[3][3]=1;
 
-    mask->t_StandardSpaceXYZtoIJK = tda_algebra_matrix_inverse(&mask->t_StandardSpaceIJKtoXYZ);
+    mask->t_StandardSpaceXYZtoIJK = tda_algebra_matrix_4x4_inverse(&mask->t_StandardSpaceIJKtoXYZ);
 
     mask->pt_RotationMatrix = &mask->t_StandardSpaceIJKtoXYZ;
     mask->pt_InverseMatrix = &mask->t_StandardSpaceXYZtoIJK;
@@ -345,7 +345,7 @@ memory_serie_create_mask_from_serie (Serie *serie)
           (mask->i16_StandardSpaceCode == NIFTI_XFORM_TALAIRACH) ||
           (mask->i16_StandardSpaceCode == NIFTI_XFORM_MNI_152))
   {
-    mask->t_StandardSpaceXYZtoIJK = tda_algebra_matrix_inverse(&mask->t_StandardSpaceIJKtoXYZ);
+    mask->t_StandardSpaceXYZtoIJK = tda_algebra_matrix_4x4_inverse(&mask->t_StandardSpaceIJKtoXYZ);
     mask->pt_RotationMatrix = &mask->t_StandardSpaceIJKtoXYZ;
     mask->pt_InverseMatrix = &mask->t_StandardSpaceXYZtoIJK;
   }
@@ -450,12 +450,12 @@ v_memory_io_handleSpace (Serie *serie)
     serie->t_ScannerSpaceIJKtoXYZ.af_Matrix[3][2] = 0;
     serie->t_ScannerSpaceIJKtoXYZ.af_Matrix[3][3] = 1;
 
-    serie->t_ScannerSpaceXYZtoIJK = tda_algebra_matrix_inverse(&serie->t_ScannerSpaceIJKtoXYZ);
+    serie->t_ScannerSpaceXYZtoIJK = tda_algebra_matrix_4x4_inverse(&serie->t_ScannerSpaceIJKtoXYZ);
   }
   else if (serie->i16_QuaternionCode == NIFTI_XFORM_SCANNER_ANAT)
   {
-    serie->t_ScannerSpaceIJKtoXYZ = tda_algebra_matrix_QuaternionToMatrix(serie->ps_Quaternion, serie->ps_QuaternationOffset, serie->d_Qfac);
-    serie->t_ScannerSpaceXYZtoIJK = tda_algebra_matrix_inverse(&serie->t_ScannerSpaceIJKtoXYZ);
+    serie->t_ScannerSpaceIJKtoXYZ = tda_algebra_matrix_4x4_QuaternionToMatrix(serie->ps_Quaternion, serie->ps_QuaternationOffset, serie->d_Qfac);
+    serie->t_ScannerSpaceXYZtoIJK = tda_algebra_matrix_4x4_inverse(&serie->t_ScannerSpaceIJKtoXYZ);
   }
 
 }


### PR DESCRIPTION
Bug fix: Dicom orientation not correct transformed to quaternion.

Fixed: Rewritten the transformation

Changes:
- Some definitions, to be uniform in function naming
  - include/lib-io-dicom.h
  - include/lib-memory-serie.h
  - lib/lib-common/lib-common-algebra.c
  - lib/lib-io-dicom/lib-io-dicom.c
  - lib/lib-io-nifti/lib-io-nifti.c
  - lib/lib-memory/lib-memory-io.c
  - lib/lib-memory/lib-memory-serie.c
- New routines for correct transformation
  - include/lib-io-dicom.h
  - lib/lib-common/lib-common-algebra.c
  - lib/lib-io-dicom/lib-io-dicom.c
  - lib/lib-memory/lib-memory-io.c
