### PR TITLE
FEATURE CHANGE: Load mask lut if max of serie is less then 255

### DIFF
--- a/include/lib-common-algebra.h
+++ b/include/lib-common-algebra.h
@@ -26,6 +26,7 @@ extern "C" {
 
 #include <assert.h>
 #include "lib-common.h"
+#include "lib-memory.h"
 
 
 /**
@@ -45,6 +46,13 @@ extern "C" {
  * This module provides Quaternion-specific functionality.
  */
 
+/**
+ * Macro to load a 3x3 matrix
+ */
+#define LOAD_MAT33(AA,a11,a12,a13 ,a21,a22,a23 ,a31,a32,a33)    \
+( AA.af_Matrix[0][0]=a11, AA.af_Matrix[1][0]=a12, AA.af_Matrix[2][0]=a13, \
+  AA.af_Matrix[0][1]=a21, AA.af_Matrix[1][1]=a22, AA.af_Matrix[2][1]=a23, \
+  AA.af_Matrix[0][2]=a31, AA.af_Matrix[1][2]=a32, AA.af_Matrix[2][2]=a33)
 
 /**
  * Macro to load a 4x4 matrix
@@ -54,6 +62,10 @@ extern "C" {
   AA.af_Matrix[0][1]=a21, AA.af_Matrix[1][1]=a22, AA.af_Matrix[2][1]=a23, AA.af_Matrix[3][1]=a24  ,   \
   AA.af_Matrix[0][2]=a31, AA.af_Matrix[1][2]=a32, AA.af_Matrix[2][2]=a33, AA.af_Matrix[3][2]=a34 , \
   AA.af_Matrix[0][3]=a41, AA.af_Matrix[1][3]=a42, AA.af_Matrix[2][3]=a43, AA.af_Matrix[3][3]=a44 )
+
+
+
+
 
 /**
  * Quaternion definition.
@@ -79,7 +91,7 @@ typedef struct
  */
 typedef struct
 {
-  double af_Matrix[3][3];
+  float af_Matrix[3][3];
 } ts_Matrix3x3;
 
 
@@ -107,6 +119,14 @@ Vector3D s_algebra_vector_perpendicular(Vector3D *ps_InputVector, Vector3D *ps_U
  * @param[out] vector     Normalized vector.
  */
 Vector3D s_algebra_vector_crossproduct(Vector3D *ps_InputVector,Vector3D *pts_perpendicularVector);
+
+/**
+ * Function that normalize a vector
+ * @param[in]  ps_Vector  Vector A.
+ * @param[in]  ps_Vector  Vector B.
+ * @param[out] float      Dot product value.
+ */
+float f_algebra_vector_dotproduct(Vector3D *ps_VectorA,Vector3D *ps_VectorB);
 
 /**
  * Function that transforms a vector according to a rotation matrix.
@@ -193,6 +213,14 @@ ts_Matrix4x4 tda_algebra_matrix_4x4_inverse(ts_Matrix4x4 *ps_Matrix);
  * @param[out] matrix      Output matrix.
  */
 ts_Matrix4x4 tda_algebra_matrix_4x4_multiply(ts_Matrix4x4 *ps_MatrixA , ts_Matrix4x4 *ps_MatrixB);
+
+/**
+ * Function that multiplys a 3x3 matrix.
+ * @param[in]  ps_MatrixA  Input matrix.
+ * @param[in]  ps_MatrixB  Input matrix.
+ * @param[out] matrix      Output matrix.
+ */
+ts_Matrix3x3 tda_algebra_matrix_3x3_multiply(ts_Matrix3x3 *ps_MatrixA , ts_Matrix3x3 *ps_MatrixB);
 
 /**
  * Function that convert a matrix to a quaternion

--- a/include/lib-common-algebra.h
+++ b/include/lib-common-algebra.h
@@ -202,7 +202,6 @@ ts_Matrix4x4 tda_algebra_matrix_4x4_multiply(ts_Matrix4x4 *ps_MatrixA , ts_Matri
  */
 ts_Quaternion ts_algebra_quaternion_MatrixToQuaternion(ts_Matrix4x4 *pt_Matrix, double *pd_Qfac);
 
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/lib-memory-serie.h
+++ b/include/lib-memory-serie.h
@@ -235,6 +235,14 @@ typedef struct
   * Maximum value in serie
   */
   int i32_MaximumValue;
+
+  /**
+  * Image Directions of image loaded
+  */
+  te_MemoryImageDirection e_ImageDirection_I;
+  te_MemoryImageDirection e_ImageDirection_J;
+  te_MemoryImageDirection e_ImageDirection_K;
+
 } Serie;
 
 
@@ -318,6 +326,49 @@ Coordinate3D memory_serie_GetPivotpoint(Serie *serie);
  * @return A [x,y,z] coordinate to the pivot point
  */
 void v_memory_io_handleSpace(Serie *serie);
+
+
+/**
+ * This function converts a rotation matrix to a orientation
+ *
+ * @param pt_Rotation       Pointer to rotation matrix
+ * @param pe_I              Pointer to I direction variable
+ * @param pe_J              Pointer to J direction variable
+ * @param pe_K              Pointer to K direction variable
+ *
+ */
+void v_memory_serie_MatrixToOrientation(ts_Matrix4x4 *pt_R , te_MemoryImageDirection *pe_I, te_MemoryImageDirection *pe_J, te_MemoryImageDirection *pe_K);
+
+/**
+ * This function converts a image orientation, specified from the coded params to a plane
+ *
+ * @param ps_serie The serie to calculate orientation from
+ *
+ * @return A plane definition
+ */
+MemoryImageOrientation e_memory_serie_ConvertImageDirectionToOrientation(te_MemoryImageDirection e_ImageDirection_I, te_MemoryImageDirection e_ImageDirection_J, te_MemoryImageDirection e_ImageDirection_K);
+
+/**
+ * This function converts a image orientation to a string
+ *
+ * @param e_ImageOrientation    The defined orientation
+ *
+ * @return A string that describes the orientation
+ */
+char *pc_memory_serie_orientation_string( MemoryImageOrientation e_ImageOrientation);
+
+/**
+ * This function converts a image orientation to a string
+ *
+ * @param e_ImageOrientation    The defined orientation
+ *
+ * @return A string that describes the orientation
+ */
+char *pc_memory_serie_direction_string(te_MemoryImageDirection e_ImageDirection, te_MemoryImageDirectionPart e_IDP);
+
+
+
+
 
 /**
  *   @}

--- a/include/lib-memory-slice.h
+++ b/include/lib-memory-slice.h
@@ -132,6 +132,14 @@ typedef struct
    */
   ViewportProperties viewportProperties;
 
+  /**
+  * Image Directions of image loaded
+  */
+  te_MemoryImageDirection e_ImageDirection_I;
+  te_MemoryImageDirection e_ImageDirection_J;
+  te_MemoryImageDirection e_ImageDirection_K;
+
+
 } Slice;
 
 /**
@@ -221,6 +229,7 @@ void memory_slice_set_PivotPoint (Slice *slice, Vector3D *ps_PivotPoint);
  * @param ps_NormalVector  Pointer to external up vector.
  */
 void memory_slice_set_UpVector (Slice *slice, Vector3D *ps_upVector);
+
 
 /**
  *    @}

--- a/include/lib-memory.h
+++ b/include/lib-memory.h
@@ -31,7 +31,7 @@
  * @defgroup memory Memory
  * @{
  *
- * This module provides an internal image format that allows other layers 
+ * This module provides an internal image format that allows other layers
  * to interact with all supported image formats in a standardized way.
  *
  * The module has been separated into several submodules which all-together
@@ -50,6 +50,27 @@ typedef enum
   ORIENTATION_CORONAL
 } MemoryImageOrientation;
 
+/**
+ * This enumeration contains all orientation directions
+ */
+typedef enum
+{
+  DIRECTION_ERROR,
+  DIRECTION_L2R,
+  DIRECTION_R2L,
+  DIRECTION_P2A,
+  DIRECTION_A2P,
+  DIRECTION_I2S,
+  DIRECTION_S2I
+} te_MemoryImageDirection;
+
+
+typedef enum
+{
+  DIRECTION_PART_ALL,
+  DIRECTION_PART_FIRST,
+  DIRECTION_PART_LAST
+} te_MemoryImageDirectionPart;
 
 /**
  * This enumeration contains all known memory types.

--- a/include/lib-viewer.h
+++ b/include/lib-viewer.h
@@ -149,6 +149,13 @@ typedef struct Viewer
   ClutterActor *c_SliceInfo; /*< A ClutterText layer to display image info. */
   ClutterActor *c_Handles; /*< A ClutterActor used for drawing handles. */
 
+  ClutterActor *c_SliceOrientationTop; /*< A ClutterText layer to display orientatiosn info. */
+  ClutterActor *c_SliceOrientationBottom; /*< A ClutterText layer to display orientatiosn info. */
+  ClutterActor *c_SliceOrientationLeft; /*< A ClutterText layer to display orientatiosn info. */
+  ClutterActor *c_SliceOrientationRight; /*< A ClutterText layer to display orientatiosn info. */
+
+
+
   Plane ts_OriginalPlane; /*< The width and height of the original data. */
   Plane ts_ScaledPlane; /*< The ts_OriginalPlane size with voxel scaling. */
   Coordinate ts_ViewPortCoordinates; /*< The previous coordinate. */
@@ -279,6 +286,8 @@ Viewer* viewer_new (Serie *ts_Original, Serie *ts_Mask, List *pll_Overlays,
                     Vector3D ts_NormalVector, Vector3D ts_PivotPoint,
                     Vector3D ts_UpVector);
 
+
+void v_viewer_set_image_orientation_direction(Viewer *pt_Viewport, char *pc_Top, char *pc_Bottom, char *pc_Left, char *pc_Right);
 
 /**
  * This function creates a clutter stage, which is a stand-alone object

--- a/lib/lib-common/lib-common-algebra.c
+++ b/lib/lib-common/lib-common-algebra.c
@@ -77,7 +77,7 @@ Vector3D s_algebra_vector_perpendicular(Vector3D *ps_InputVector, Vector3D *ps_U
 
   if (f_UpMagnitude < 0.0000001)
   {
-    //Second try at making a View Up vector: Use Y axis default  (0,1,0)
+    //Second try at making a View Up vector: Use Y ats_I.xs default  (0,1,0)
     ts_perpendicularVector.x = -ps_InputVector->y * ps_InputVector->x;
     ts_perpendicularVector.y = 1-ps_InputVector->y * ps_InputVector->y;
     ts_perpendicularVector.z = -ps_InputVector->y * ps_InputVector->z;
@@ -87,7 +87,7 @@ Vector3D s_algebra_vector_perpendicular(Vector3D *ps_InputVector, Vector3D *ps_U
 
     if (f_UpMagnitude < 0.0000001)
     {
-          //Final try at making a View Up vector: Use Z axis default  (0,0,1)
+          //Final try at making a View Up vector: Use Z ats_I.xs default  (0,0,1)
       ts_perpendicularVector.x = -ps_InputVector->z * ps_InputVector->x;
       ts_perpendicularVector.y = -ps_InputVector->z * ps_InputVector->y;
       ts_perpendicularVector.z = 1-ps_InputVector->z * ps_InputVector->z;
@@ -123,6 +123,19 @@ Vector3D s_algebra_vector_crossproduct(Vector3D *ps_InputVector,Vector3D *pts_pe
   return s_OutputVector;
 }
 
+float f_algebra_vector_dotproduct(Vector3D *ps_VectorA,Vector3D *ps_VectorB)
+{
+  debug_functions ();
+
+  float f_DotProduct;
+
+  f_DotProduct  = ps_VectorA->x * ps_VectorB->x;
+  f_DotProduct += ps_VectorA->y * ps_VectorB->y;
+  f_DotProduct += ps_VectorA->z * ps_VectorB->z;
+
+  return f_DotProduct;
+}
+
 Vector3D ts_algebra_vector_translate(ts_Matrix4x4 *ps_Matrix, Vector3D *ps_Vector)
 {
   Vector3D ts_MultiplyVector;
@@ -145,9 +158,9 @@ Vector3D ts_algebra_vector_translate(ts_Matrix4x4 *ps_Matrix, Vector3D *ps_Vecto
   return ts_MultiplyVector;
 }
 
-Vector3D ts_algebra_vector_Rotation_around_X_Axis (Vector3D *ps_Vector, float f_angle)
+Vector3D ts_algebra_vector_Rotation_around_X_Axis(Vector3D *ps_Vector, float f_angle)
 {
-  /* Rotation vector around x-axis (http://en.wikipedia.org/wiki/Rotation_matrix)
+  /* Rotation vector around x-ats_I.xs (http://en.wikipedia.org/wiki/Rotation_matrix)
           | 1  0    0  |   | x |
       R = | 0 cos -sin | * | y |
           | 0 sin  cos |   | z |
@@ -164,7 +177,7 @@ Vector3D ts_algebra_vector_Rotation_around_X_Axis (Vector3D *ps_Vector, float f_
 
 Vector3D ts_algebra_vector_Rotation_around_Y_Axis (Vector3D *ps_Vector, float f_angle)
 {
-  /* Rotation vector around y-axis (http://en.wikipedia.org/wiki/Rotation_matrix)
+  /* Rotation vector around y-ats_I.xs (http://en.wikipedia.org/wiki/Rotation_matrix)
           |  cos  0  sin |   | x |
       R = |   0   1   0  | * | y |
           | -sin  0  cos |   | z |
@@ -178,9 +191,9 @@ Vector3D ts_algebra_vector_Rotation_around_Y_Axis (Vector3D *ps_Vector, float f_
   return ts_rotatedVector;
 }
 
-Vector3D ts_algebra_vector_Rotation_around_Z_Axis (Vector3D *ps_Vector, float f_angle)
+Vector3D ts_algebra_vector_Rotation_around_Z_Axis(Vector3D *ps_Vector, float f_angle)
 {
-  /* Rotation vector around z-axis (http://en.wikipedia.org/wiki/Rotation_matrix)
+  /* Rotation vector around z-ats_I.xs (http://en.wikipedia.org/wiki/Rotation_matrix)
           | cos -sin 0  |   | x |
       R = | sin  cos 0  | * | y |
           |  0    0  1  |   | z |
@@ -390,6 +403,55 @@ ts_Matrix4x4 tda_algebra_matrix_4x4_multiply(ts_Matrix4x4 *ps_MatrixA , ts_Matri
     return t_Result;
 }
 
+ts_Matrix3x3 tda_algebra_matrix_3x3_multiply(ts_Matrix3x3 *ps_MatrixA , ts_Matrix3x3 *ps_MatrixB)
+{
+  ts_Matrix3x3 t_Result;
+  short int i16_ColumnCnt;
+  short int i16_RowCnt;
+  short int i16_SumCnt;
+
+  for( i16_ColumnCnt=0; i16_ColumnCnt < 3; i16_ColumnCnt++)
+  {
+    for( i16_RowCnt=0; i16_RowCnt < 3; i16_RowCnt++)
+    {
+      t_Result.af_Matrix[i16_ColumnCnt][i16_RowCnt] = 0;
+      for (i16_SumCnt=0; i16_SumCnt < 3; i16_SumCnt++)
+      {
+        t_Result.af_Matrix[i16_ColumnCnt][i16_RowCnt] += ps_MatrixA->af_Matrix[i16_SumCnt][i16_RowCnt] * ps_MatrixB->af_Matrix[i16_ColumnCnt][i16_SumCnt];
+      }
+    }
+  }
+  return t_Result;
+}
+
+
+float f_algebra_matrix_3x3_Determinant(ts_Matrix3x3 *ps_RotationsMatrix )   /* determinant of 3x3 matrix */
+{
+   float r11,r12,r13,r21,r22,r23,r31,r32,r33 ;
+   float f_Determinant;
+
+   /* [ r11 r12 r13 ] */
+   /* [ r21 r22 r23 ] */
+   /* [ r31 r32 r33 ] */
+                                                       /*  INPUT MATRIX:  */
+   r11 = ps_RotationsMatrix->af_Matrix[0][0];
+   r12 = ps_RotationsMatrix->af_Matrix[1][0];
+   r13 = ps_RotationsMatrix->af_Matrix[2][0];
+
+   r21 = ps_RotationsMatrix->af_Matrix[0][1];
+   r22 = ps_RotationsMatrix->af_Matrix[1][1];
+   r23 = ps_RotationsMatrix->af_Matrix[2][1];
+
+   r31 = ps_RotationsMatrix->af_Matrix[0][2];
+   r32 = ps_RotationsMatrix->af_Matrix[1][2];
+   r33 = ps_RotationsMatrix->af_Matrix[2][2];
+
+
+   f_Determinant = r11*r22*r33 - r11*r32*r23 - r21*r12*r33 +
+                   r21*r32*r13 + r31*r12*r23 - r31*r22*r13;
+
+   return f_Determinant;
+}
 
 ts_Quaternion ts_algebra_quaternion_MatrixToQuaternion(ts_Matrix4x4 *pt_Matrix, double *pd_Qfac)
 {
@@ -436,7 +498,7 @@ ts_Quaternion ts_algebra_quaternion_MatrixToQuaternion(ts_Matrix4x4 *pt_Matrix, 
       So, now find the orthogonal matrix closest to the current matrix.
 
       One reason for using the polar decomposition to get this
-      orthogonal matrix, rather than just directly orthogonalizing
+      orthogonal matrix, rather than just directly orthogonalits_I.zng
       the columns, is so that inputting the inverse matrix to R
       will result in the inverse orthogonal matrix at this point.
       If we just orthogonalized the columns, this wouldn't necessarily hold. */
@@ -527,4 +589,6 @@ ts_Quaternion ts_algebra_quaternion_MatrixToQuaternion(ts_Matrix4x4 *pt_Matrix, 
 
   return ts_Quat;
 }
+
+
 

--- a/lib/lib-common/lib-common-algebra.c
+++ b/lib/lib-common/lib-common-algebra.c
@@ -128,19 +128,19 @@ Vector3D ts_algebra_vector_translate(ts_Matrix4x4 *ps_Matrix, Vector3D *ps_Vecto
   Vector3D ts_MultiplyVector;
 
   ts_MultiplyVector.x = ps_Vector->x  * ps_Matrix->af_Matrix[0][0] +
-                        ps_Vector->y  * ps_Matrix->af_Matrix[0][1] +
-                        ps_Vector->z  * ps_Matrix->af_Matrix[0][2] +
-                        ps_Matrix->af_Matrix[0][3];
+                        ps_Vector->y  * ps_Matrix->af_Matrix[1][0] +
+                        ps_Vector->z  * ps_Matrix->af_Matrix[2][0] +
+                        ps_Matrix->af_Matrix[3][0];
 
-  ts_MultiplyVector.y = ps_Vector->x  * ps_Matrix->af_Matrix[1][0] +
+  ts_MultiplyVector.y = ps_Vector->x  * ps_Matrix->af_Matrix[0][1] +
                         ps_Vector->y  * ps_Matrix->af_Matrix[1][1] +
-                        ps_Vector->z  * ps_Matrix->af_Matrix[1][2] +
-                        ps_Matrix->af_Matrix[1][3];
+                        ps_Vector->z  * ps_Matrix->af_Matrix[2][1] +
+                        ps_Matrix->af_Matrix[3][1];
 
-  ts_MultiplyVector.z = ps_Vector->x  * ps_Matrix->af_Matrix[2][0] +
-                        ps_Vector->y  * ps_Matrix->af_Matrix[2][1] +
+  ts_MultiplyVector.z = ps_Vector->x  * ps_Matrix->af_Matrix[0][2] +
+                        ps_Vector->y  * ps_Matrix->af_Matrix[1][2] +
                         ps_Vector->z  * ps_Matrix->af_Matrix[2][2] +
-                        ps_Matrix->af_Matrix[2][3];
+                        ps_Matrix->af_Matrix[3][2];
 
   return ts_MultiplyVector;
 }
@@ -527,9 +527,4 @@ ts_Quaternion ts_algebra_quaternion_MatrixToQuaternion(ts_Matrix4x4 *pt_Matrix, 
 
   return ts_Quat;
 }
-
-
-
-
-
 

--- a/lib/lib-io-nifti/lib-io-nifti.c
+++ b/lib/lib-io-nifti/lib-io-nifti.c
@@ -632,46 +632,46 @@ memory_io_niftii_load (Serie *serie, const char *pc_Filename, const char *pc_Ima
       serie->i16_StandardSpaceCode = ps_Header->sform_code;
 
       serie->t_StandardSpaceIJKtoXYZ.af_Matrix[0][0]=ps_Header->srow_x[0];// / t_Maximum.x;
-      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[0][1]=ps_Header->srow_x[1];// / t_Maximum.x;
-      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[0][2]=ps_Header->srow_x[2];// / t_Maximum.x;
-      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[0][3]=ps_Header->srow_x[3];
+      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[1][0]=ps_Header->srow_x[1];// / t_Maximum.x;
+      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[2][0]=ps_Header->srow_x[2];// / t_Maximum.x;
+      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[3][0]=ps_Header->srow_x[3];
 
-      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[1][0]=ps_Header->srow_y[0];// / t_Maximum.y;
+      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[0][1]=ps_Header->srow_y[0];// / t_Maximum.y;
       serie->t_StandardSpaceIJKtoXYZ.af_Matrix[1][1]=ps_Header->srow_y[1];// / t_Maximum.y;
-      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[1][2]=ps_Header->srow_y[2];// / t_Maximum.y;
-      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[1][3]=ps_Header->srow_y[3];
+      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[2][1]=ps_Header->srow_y[2];// / t_Maximum.y;
+      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[3][1]=ps_Header->srow_y[3];
 
-      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[2][0]=ps_Header->srow_z[0];// / t_Maximum.z;
-      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[2][1]=ps_Header->srow_z[1];// / t_Maximum.z;
+      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[0][2]=ps_Header->srow_z[0];// / t_Maximum.z;
+      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[1][2]=ps_Header->srow_z[1];// / t_Maximum.z;
       serie->t_StandardSpaceIJKtoXYZ.af_Matrix[2][2]=ps_Header->srow_z[2];// / t_Maximum.z;
-      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[2][3]=ps_Header->srow_z[3];
+      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[3][2]=ps_Header->srow_z[3];
 
-      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[3][0]=0;
-      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[3][1]=0;
-      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[3][2]=0;
+      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[0][3]=0;
+      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[1][3]=0;
+      serie->t_StandardSpaceIJKtoXYZ.af_Matrix[2][3]=0;
       serie->t_StandardSpaceIJKtoXYZ.af_Matrix[3][3]=1;
 
       if((serie->i16_StandardSpaceCode == NIFTI_XFORM_UNKNOWN) &&
          (serie->i16_QuaternionCode == NIFTI_XFORM_UNKNOWN))
       {
         serie->t_StandardSpaceIJKtoXYZ.af_Matrix[0][0]=1;
-        serie->t_StandardSpaceIJKtoXYZ.af_Matrix[0][1]=0;
-        serie->t_StandardSpaceIJKtoXYZ.af_Matrix[0][2]=0;
-        serie->t_StandardSpaceIJKtoXYZ.af_Matrix[0][3]=0;
-
         serie->t_StandardSpaceIJKtoXYZ.af_Matrix[1][0]=0;
-        serie->t_StandardSpaceIJKtoXYZ.af_Matrix[1][1]=1;
-        serie->t_StandardSpaceIJKtoXYZ.af_Matrix[1][2]=0;
-        serie->t_StandardSpaceIJKtoXYZ.af_Matrix[1][3]=0;
-
         serie->t_StandardSpaceIJKtoXYZ.af_Matrix[2][0]=0;
-        serie->t_StandardSpaceIJKtoXYZ.af_Matrix[2][1]=0;
-        serie->t_StandardSpaceIJKtoXYZ.af_Matrix[2][2]=1;
-        serie->t_StandardSpaceIJKtoXYZ.af_Matrix[2][3]=0;
-
         serie->t_StandardSpaceIJKtoXYZ.af_Matrix[3][0]=0;
+
+        serie->t_StandardSpaceIJKtoXYZ.af_Matrix[0][1]=0;
+        serie->t_StandardSpaceIJKtoXYZ.af_Matrix[1][1]=1;
+        serie->t_StandardSpaceIJKtoXYZ.af_Matrix[2][1]=0;
         serie->t_StandardSpaceIJKtoXYZ.af_Matrix[3][1]=0;
+
+        serie->t_StandardSpaceIJKtoXYZ.af_Matrix[0][2]=0;
+        serie->t_StandardSpaceIJKtoXYZ.af_Matrix[1][2]=0;
+        serie->t_StandardSpaceIJKtoXYZ.af_Matrix[2][2]=1;
         serie->t_StandardSpaceIJKtoXYZ.af_Matrix[3][2]=0;
+
+        serie->t_StandardSpaceIJKtoXYZ.af_Matrix[0][3]=0;
+        serie->t_StandardSpaceIJKtoXYZ.af_Matrix[1][3]=0;
+        serie->t_StandardSpaceIJKtoXYZ.af_Matrix[2][3]=0;
         serie->t_StandardSpaceIJKtoXYZ.af_Matrix[3][3]=1;
 
         serie->t_StandardSpaceXYZtoIJK = tda_algebra_matrix_4x4_inverse(&serie->t_StandardSpaceIJKtoXYZ);
@@ -690,15 +690,6 @@ memory_io_niftii_load (Serie *serie, const char *pc_Filename, const char *pc_Ima
       else if(serie->i16_QuaternionCode == NIFTI_XFORM_SCANNER_ANAT)
       {
         v_memory_io_handleSpace (serie);
-
-  Serie *ps_serie = serie;
-  printf("Translation matrix in scannerspace:\n");
-  printf("%10.2f, %10.2f, %10.2f, %10.2f \n", ps_serie->t_ScannerSpaceIJKtoXYZ.af_Matrix[0][0], ps_serie->t_ScannerSpaceIJKtoXYZ.af_Matrix[1][0], ps_serie->t_ScannerSpaceIJKtoXYZ.af_Matrix[2][0], ps_serie->t_ScannerSpaceIJKtoXYZ.af_Matrix[3][0]);
-  printf("%10.2f, %10.2f, %10.2f, %10.2f \n", ps_serie->t_ScannerSpaceIJKtoXYZ.af_Matrix[0][1], ps_serie->t_ScannerSpaceIJKtoXYZ.af_Matrix[1][1], ps_serie->t_ScannerSpaceIJKtoXYZ.af_Matrix[2][1], ps_serie->t_ScannerSpaceIJKtoXYZ.af_Matrix[3][1]);
-  printf("%10.2f, %10.2f, %10.2f, %10.2f \n", ps_serie->t_ScannerSpaceIJKtoXYZ.af_Matrix[0][2], ps_serie->t_ScannerSpaceIJKtoXYZ.af_Matrix[1][2], ps_serie->t_ScannerSpaceIJKtoXYZ.af_Matrix[2][2], ps_serie->t_ScannerSpaceIJKtoXYZ.af_Matrix[3][2]);
-  printf("%10.2f, %10.2f, %10.2f, %10.2f \n", ps_serie->t_ScannerSpaceIJKtoXYZ.af_Matrix[0][3], ps_serie->t_ScannerSpaceIJKtoXYZ.af_Matrix[1][3], ps_serie->t_ScannerSpaceIJKtoXYZ.af_Matrix[2][3], ps_serie->t_ScannerSpaceIJKtoXYZ.af_Matrix[3][3]);
-  printf("\n");
-
 
         serie->pt_RotationMatrix = &serie->t_ScannerSpaceIJKtoXYZ;
         serie->pt_InverseMatrix = &serie->t_ScannerSpaceXYZtoIJK;
@@ -731,7 +722,6 @@ memory_io_niftii_load (Serie *serie, const char *pc_Filename, const char *pc_Ima
       }
     }
     memory_serie_set_upper_and_lower_borders_from_data(serie);
-
     return 1;
   }
 

--- a/lib/lib-memory/lib-memory-io.c
+++ b/lib/lib-memory/lib-memory-io.c
@@ -516,7 +516,6 @@ Tree *pt_memory_io_load_file_dicom (Tree **patient_tree, char *pc_path)
   return pt_serie;
 }
 
-
 /*                                                                                                    */
 /*                                                                                                    */
 /* GLOBAL FUNCTIONS                                                                                   */
@@ -546,23 +545,21 @@ Tree *pt_memory_io_load_file (Tree **ppt_study, char *pc_path)
     pt_SerieTree = pt_memory_io_load_file_dicom(&pt_patient, pc_path);
   }
 
-  if (pt_SerieTree != NULL)
+/*  if (pt_SerieTree != NULL)
   {
     ps_Serie = pt_SerieTree->data;
 
+    MemoryImageOrientation e_Orientation;
 
-/*
-    mat44 testje;
+    v_memory_serie_MatrixToOrientation(ps_Serie->pt_RotationMatrix, &ps_Serie->e_ImageDirection_I, &ps_Serie->e_ImageDirection_J, &ps_Serie->e_ImageDirection_K);
+    e_Orientation = e_memory_serie_ConvertImageDirectionToOrientation(ps_Serie->e_ImageDirection_I, ps_Serie->e_ImageDirection_J, ps_Serie->e_ImageDirection_K);
 
-    testje = nifti_make_orthog_mat44(ps_Serie ->pt_RotationMatrix->af_Matrix[0][0],ps_Serie ->pt_RotationMatrix->af_Matrix[1][0],ps_Serie ->pt_RotationMatrix->af_Matrix[2][0],
-                                     ps_Serie ->pt_RotationMatrix->af_Matrix[0][1],ps_Serie ->pt_RotationMatrix->af_Matrix[1][1],ps_Serie ->pt_RotationMatrix->af_Matrix[2][1],
-                                     ps_Serie ->pt_RotationMatrix->af_Matrix[0][2],ps_Serie ->pt_RotationMatrix->af_Matrix[1][2],ps_Serie ->pt_RotationMatrix->af_Matrix[2][2]);
+    printf("%s\n",pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_I));
+    printf("%s\n",pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_J));
+    printf("%s\n",pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_K));
 
-*/
-//    v_print_Matrix(ps_Serie->pt_RotationMatrix);
-//    v_print_Matrix(&testje);
   }
-
+*/
 
 
   return pt_SerieTree;

--- a/lib/lib-memory/lib-memory-io.c
+++ b/lib/lib-memory/lib-memory-io.c
@@ -524,6 +524,8 @@ Tree *pt_memory_io_load_file_dicom (Tree **patient_tree, char *pc_path)
 /*                                                                                                    */
 Tree *pt_memory_io_load_file (Tree **ppt_study, char *pc_path)
 {
+  Tree *pt_SerieTree=NULL;
+  Serie *ps_Serie;
   Tree *pt_patient=NULL
   debug_functions ();
 
@@ -535,15 +537,35 @@ Tree *pt_memory_io_load_file (Tree **ppt_study, char *pc_path)
   // check wheater it is a niftii
   if (memory_io_niftii_file_type(pc_path) != MUMC_FILETYPE_NOT_KNOWN)
   {
-    return pt_memory_io_load_file_nifti(&(*ppt_study),pc_path);
+    pt_SerieTree = pt_memory_io_load_file_nifti(&(*ppt_study),pc_path);
   }
   else
   {
     // maybe a dicom?
     pt_patient=((*ppt_study) == NULL)?NULL:(*ppt_study)->parent;
-    return pt_memory_io_load_file_dicom(&pt_patient, pc_path);
+    pt_SerieTree = pt_memory_io_load_file_dicom(&pt_patient, pc_path);
   }
-  return NULL;
+
+  if (pt_SerieTree != NULL)
+  {
+    ps_Serie = pt_SerieTree->data;
+
+
+/*
+    mat44 testje;
+
+    testje = nifti_make_orthog_mat44(ps_Serie ->pt_RotationMatrix->af_Matrix[0][0],ps_Serie ->pt_RotationMatrix->af_Matrix[1][0],ps_Serie ->pt_RotationMatrix->af_Matrix[2][0],
+                                     ps_Serie ->pt_RotationMatrix->af_Matrix[0][1],ps_Serie ->pt_RotationMatrix->af_Matrix[1][1],ps_Serie ->pt_RotationMatrix->af_Matrix[2][1],
+                                     ps_Serie ->pt_RotationMatrix->af_Matrix[0][2],ps_Serie ->pt_RotationMatrix->af_Matrix[1][2],ps_Serie ->pt_RotationMatrix->af_Matrix[2][2]);
+
+*/
+//    v_print_Matrix(ps_Serie->pt_RotationMatrix);
+//    v_print_Matrix(&testje);
+  }
+
+
+
+  return pt_SerieTree;
 }
 
 short int memory_io_save_file (Serie *serie, const char *path)

--- a/lib/lib-pixeldata/lib-pixeldata.c
+++ b/lib/lib-pixeldata/lib-pixeldata.c
@@ -356,6 +356,10 @@ short int
 pixeldata_calculate_window_width_level (PixelData *pixeldata, int i32_deltaWidth, int i32_deltaLevel)
 {
   debug_functions ();
+  if (pixeldata == NULL)
+  {
+    return 0;
+  }
 
   pixeldata->ts_WWWL.i32_windowWidth += i32_deltaWidth;
   if (pixeldata->ts_WWWL.i32_windowWidth > pixeldata->serie->i32_MaximumValue)
@@ -519,7 +523,7 @@ pixeldata_get_pixel_value_as_string (PixelData *pixeldata, Coordinate ts_Point)
   short int i16_Y  = (short int)ts_Point.y;
 
   source += (unsigned int)(i16_Y * slice->matrix.i16_x + i16_X);
-
+/*
   switch (pixeldata->serie->data_type)
   {
     case MEMORY_TYPE_INT8       : sprintf (output, "%c", *((char*)*source)); break;
@@ -532,6 +536,8 @@ pixeldata_get_pixel_value_as_string (PixelData *pixeldata, Coordinate ts_Point)
     case MEMORY_TYPE_FLOAT64    : sprintf (output, "%.2f", *((double*)*source)); break;
     default                     : sprintf (output, "Unknown"); break;
   }
+  */
+sprintf (output, "Unknown");
 
   return output;
 }

--- a/lib/lib-viewer/lib-viewer.c
+++ b/lib/lib-viewer/lib-viewer.c
@@ -1227,7 +1227,18 @@ viewer_initialize (Viewer *resources, Serie *ts_Original, Serie *ts_Mask, List *
   memory_slice_set_UpVector(slice,&resources->ts_UpVector);
 
   // Set the default window and level.
-  PixelDataLookupTable *default_lut = pixeldata_lookup_table_get_default ();
+  Serie *ps_serie=slice->serie;
+  PixelDataLookupTable *default_lut;
+
+  if (ps_serie->i32_MaximumValue < 255)
+  {
+    default_lut = pixeldata_lookup_table_get_default_mask();
+  }
+  else
+  {
+    default_lut = pixeldata_lookup_table_get_default ();
+  }
+
   resources->ps_Original = pixeldata_new_with_lookup_table (default_lut, i32_windowWidth ,
                                                             i32_windowLevel, slice, ts_Original);
 
@@ -1323,7 +1334,18 @@ viewer_new (Serie *ts_Original, Serie *ts_Mask, List *pll_Overlays,
   memory_slice_set_UpVector(slice,&resources->ts_UpVector);
 
   // Set the default window and level.
-  PixelDataLookupTable *default_lut = pixeldata_lookup_table_get_default ();
+
+  PixelDataLookupTable *default_lut;
+
+  if (ts_Original->i32_MaximumValue < 255)
+  {
+    default_lut = pixeldata_lookup_table_get_default_mask();
+  }
+  else
+  {
+    default_lut = pixeldata_lookup_table_get_default ();
+  }
+
   resources->ps_Original = pixeldata_new_with_lookup_table (default_lut, i32_windowWidth ,
                                                             i32_windowLevel, slice, ts_Original);
 

--- a/lib/lib-viewer/lib-viewer.c
+++ b/lib/lib-viewer/lib-viewer.c
@@ -1230,9 +1230,11 @@ viewer_initialize (Viewer *resources, Serie *ts_Original, Serie *ts_Mask, List *
   Serie *ps_serie=slice->serie;
   PixelDataLookupTable *default_lut;
 
-  if (ps_serie->i32_MaximumValue < 255)
+  if (ps_serie->i32_MaximumValue < 16)
   {
     default_lut = pixeldata_lookup_table_get_default_mask();
+    i32_windowWidth = 15;
+    i32_windowLevel = 8;
   }
   else
   {
@@ -1337,9 +1339,11 @@ viewer_new (Serie *ts_Original, Serie *ts_Mask, List *pll_Overlays,
 
   PixelDataLookupTable *default_lut;
 
-  if (ts_Original->i32_MaximumValue < 255)
+  if (ts_Original->i32_MaximumValue < 16)
   {
     default_lut = pixeldata_lookup_table_get_default_mask();
+    i32_windowWidth = 15;
+    i32_windowLevel = 8;
   }
   else
   {
@@ -1706,10 +1710,35 @@ viewer_add_overlay_serie (Viewer *resources, Serie *serie)
   if (serie->i32_MaximumValue == 0)
     serie->i32_MaximumValue = 255;
 
-  PixelDataLookupTable *overlay_lut = pixeldata_lookup_table_get_default_overlay ();
+  PixelDataLookupTable *overlay_lut;
+
+  int i32_windowWidth, i32_windowLevel;
+
+  i32_windowWidth = serie->i32_MaximumValue - serie->i32_MinimumValue;
+  i32_windowLevel = serie->i32_MaximumValue/2;
+
+  if (i32_windowLevel == 0)
+  {
+    i32_windowLevel = 1;
+  }
+
+  if (serie->i32_MaximumValue < 16)
+  {
+    overlay_lut = pixeldata_lookup_table_get_default_mask();
+  }
+  else if (serie->i32_MaximumValue < 255)
+  {
+    overlay_lut = pixeldata_lookup_table_get_default_overlay ();
+  }
+  else
+  {
+    overlay_lut = pixeldata_lookup_table_get_default();
+  }
+
+
   overlay = pixeldata_new_with_lookup_table (overlay_lut,
-					     serie->i32_MaximumValue - serie->i32_MinimumValue,
-					     serie->i32_MaximumValue/2,
+					     i32_windowWidth,
+					     i32_windowLevel,
 					     overlay_slice,
 					     serie);
   assert (overlay != NULL);

--- a/plugin/plugin-interface.c
+++ b/plugin/plugin-interface.c
@@ -30,7 +30,6 @@ CLM_Plugin_DrawPixelAtPoint (PixelData *ps_Mask, PixelData *ps_Selection,
   void **ppv_ImageDataCounter = PIXELDATA_ACTIVE_SLICE_DATA (ps_Mask);
   ppv_ImageDataCounter += (unsigned int)(ts_Point.y * mask_slice->matrix.i16_x + ts_Point.x);
 
-
   if (*ppv_ImageDataCounter == mask_slice->serie->pv_OutOfBlobValue)
   {
     return 0;

--- a/source/gui/mainwindow.c
+++ b/source/gui/mainwindow.c
@@ -681,7 +681,7 @@ gui_mainwindow_file_load (void* data)
   debug_functions ();
 
   Tree *pt_Serie=NULL;
-  Serie *ps_serie = NULL;
+  Serie *ps_Serie = NULL;
   char* filename = NULL;
 
   // The filename can be passed by 'data'. Otherwise we need to show a
@@ -702,8 +702,8 @@ gui_mainwindow_file_load (void* data)
 
     if (pt_Serie != NULL)
     {
-      ps_serie = pt_Serie->data;
-      ps_serie->e_SerieType=SERIE_ORIGINAL;
+      ps_Serie = pt_Serie->data;
+      ps_Serie->e_SerieType=SERIE_ORIGINAL;
 
       gui_mainwindow_load_serie(pt_Serie);
 
@@ -775,10 +775,123 @@ gui_mainwindow_load_serie (Tree *pt_Serie)
   gui_mainwindow_sidebar_populate (root_tree);
   gui_mainwindow_layer_manager_refresh (CONFIGURATION_ACTIVE_SERIE(config));
 
-  Serie *serie = pt_Serie->data;
-  if (serie == NULL || ts_ActiveMask == NULL) return;
+  ps_Serie = pt_Serie->data;
+  if (ps_Serie == NULL || ts_ActiveMask == NULL) return;
 
-  gtk_range_set_range (GTK_RANGE (timeline), 1, serie->num_time_series);
+  gtk_range_set_range (GTK_RANGE (timeline), 1, ps_Serie->num_time_series);
+
+  MemoryImageOrientation e_Orientation;
+  v_memory_serie_MatrixToOrientation(ps_Serie->pt_RotationMatrix, &ps_Serie->e_ImageDirection_I, &ps_Serie->e_ImageDirection_J, &ps_Serie->e_ImageDirection_K);
+  e_Orientation = e_memory_serie_ConvertImageDirectionToOrientation(ps_Serie->e_ImageDirection_I, ps_Serie->e_ImageDirection_J, ps_Serie->e_ImageDirection_K);
+
+  char *pc_Axial_Top  , *pc_Axial_Bottom  , *pc_Axial_Left  , *pc_Axial_Right;
+  char *pc_Sagital_Top, *pc_Sagital_Bottom, *pc_Sagital_Left, *pc_Sagital_Right;
+  char *pc_Coronal_Top, *pc_Coronal_Bottom, *pc_Coronal_Left, *pc_Coronal_Right;
+
+  Serie *ps_RotatedSerie = memory_serie_new("test","test");
+  ts_Matrix4x4 ta_RotationAroundAxis, ta_TMP;
+
+  Vector3D ts_Normal_Axial;
+  Vector3D ts_Normal_Sagital;
+  Vector3D ts_Normal_Coronal;
+
+  Vector3D ts_Up_Axial;
+  Vector3D ts_Up_Sagital;
+  Vector3D ts_Up_Coronal;
+
+  Vector3D ts_Pivot;
+  ts_Pivot = memory_serie_GetPivotpoint(ps_Serie);
+
+
+  if (e_Orientation != ORIENTATION_UNKNOWN )
+  {
+    switch (e_Orientation)
+    {
+      case ORIENTATION_AXIAL :
+        pc_Axial_Top    = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_J,DIRECTION_PART_LAST);
+        pc_Axial_Bottom = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_J,DIRECTION_PART_FIRST);
+        pc_Axial_Left   = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_I,DIRECTION_PART_FIRST);
+        pc_Axial_Right  = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_I,DIRECTION_PART_LAST);
+
+        pc_Sagital_Top    = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_K,DIRECTION_PART_FIRST);
+        pc_Sagital_Bottom = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_K,DIRECTION_PART_LAST);
+        pc_Sagital_Left   = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_J,DIRECTION_PART_LAST);
+        pc_Sagital_Right  = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_J,DIRECTION_PART_FIRST);
+
+        pc_Coronal_Top    = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_K,DIRECTION_PART_FIRST);
+        pc_Coronal_Bottom = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_K,DIRECTION_PART_LAST);
+        pc_Coronal_Left   = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_I,DIRECTION_PART_FIRST);
+        pc_Coronal_Right  = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_I,DIRECTION_PART_LAST);
+
+        te_DisplayType = VIEWPORT_TYPE_AXIAL;
+        ts_Normal_Axial.x   = 0;  ts_Normal_Axial.y   = 0;  ts_Normal_Axial.z   = -1;
+        ts_Up_Axial.x       = 0;  ts_Up_Axial.y       = 1;  ts_Up_Axial.z       =  0;
+
+        ts_Normal_Sagital.x = 1;  ts_Normal_Sagital.y = 0;  ts_Normal_Sagital.z =  0;
+        ts_Up_Sagital.x     = 0;  ts_Up_Sagital.y     = 0;  ts_Up_Sagital.z     =  1;
+
+        ts_Normal_Coronal.x = 0;  ts_Normal_Coronal.y = 1;  ts_Normal_Coronal.z =  0;
+        ts_Up_Coronal.x     = 0;  ts_Up_Coronal.y     = 1;  ts_Up_Coronal.z     =  0;
+        break;
+
+      case ORIENTATION_SAGITAL :
+        pc_Sagital_Top    = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_J,DIRECTION_PART_FIRST);
+        pc_Sagital_Bottom = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_J,DIRECTION_PART_LAST);
+        pc_Sagital_Left   = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_I,DIRECTION_PART_FIRST);
+        pc_Sagital_Right  = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_I,DIRECTION_PART_LAST);
+
+        pc_Axial_Top    = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_I,DIRECTION_PART_FIRST);
+        pc_Axial_Bottom = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_I,DIRECTION_PART_LAST);
+        pc_Axial_Left   = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_K,DIRECTION_PART_FIRST);
+        pc_Axial_Right  = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_K,DIRECTION_PART_LAST);
+
+        pc_Coronal_Top    = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_J,DIRECTION_PART_FIRST);
+        pc_Coronal_Bottom = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_J,DIRECTION_PART_LAST);
+        pc_Coronal_Left   = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_K,DIRECTION_PART_FIRST);
+        pc_Coronal_Right  = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_K,DIRECTION_PART_LAST);
+
+        te_DisplayType = VIEWPORT_TYPE_SAGITAL;
+        ts_Normal_Axial.x   = 0;  ts_Normal_Axial.y   = -1; ts_Normal_Axial.z   =  0;
+        ts_Up_Axial.x       = 1;  ts_Up_Axial.y       =  0; ts_Up_Axial.z       =  0;
+
+        ts_Normal_Sagital.x = 0;  ts_Normal_Sagital.y =  0; ts_Normal_Sagital.z = -1;
+        ts_Up_Sagital.x     = 0;  ts_Up_Sagital.y     =  1; ts_Up_Sagital.z     =  0;
+
+        ts_Normal_Coronal.x = 1;  ts_Normal_Coronal.y =  0; ts_Normal_Coronal.z =  0;
+        ts_Up_Coronal.x     = 0;  ts_Up_Coronal.y     =  1; ts_Up_Coronal.z     =  0;
+        break;
+
+      case ORIENTATION_CORONAL :
+        pc_Coronal_Top    = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_J,DIRECTION_PART_LAST);
+        pc_Coronal_Bottom = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_J,DIRECTION_PART_FIRST);
+        pc_Coronal_Left   = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_I,DIRECTION_PART_LAST);
+        pc_Coronal_Right  = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_I,DIRECTION_PART_FIRST);
+
+
+        pc_Sagital_Top    = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_J,DIRECTION_PART_LAST);
+        pc_Sagital_Bottom = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_J,DIRECTION_PART_FIRST);
+        pc_Sagital_Left   = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_K,DIRECTION_PART_LAST);
+        pc_Sagital_Right  = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_K,DIRECTION_PART_FIRST);
+
+        pc_Axial_Top    = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_K,DIRECTION_PART_LAST);
+        pc_Axial_Bottom = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_K,DIRECTION_PART_FIRST);
+        pc_Axial_Left   = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_I,DIRECTION_PART_FIRST);
+        pc_Axial_Right  = pc_memory_serie_direction_string(ps_Serie->e_ImageDirection_I,DIRECTION_PART_LAST);
+
+        te_DisplayType = VIEWPORT_TYPE_CORONAL;
+        ts_Normal_Axial.x   = 0;  ts_Normal_Axial.y   =  1; ts_Normal_Axial.z   =  0;
+        ts_Up_Axial.x       = 0;  ts_Up_Axial.y       =  1; ts_Up_Axial.z       =  0;
+
+        ts_Normal_Sagital.x = 1;  ts_Normal_Sagital.y =  0; ts_Normal_Sagital.z =  0;
+        ts_Up_Sagital.x     = 1;  ts_Up_Sagital.y     =  0; ts_Up_Sagital.z     =  0;
+
+        ts_Normal_Coronal.x = 0;  ts_Normal_Coronal.y =  0; ts_Normal_Coronal.z = -1;
+        ts_Up_Coronal.x     = 0;  ts_Up_Coronal.y     =  1; ts_Up_Coronal.z     =  0;
+        break;
+    }
+  }
+
+  free(ps_RotatedSerie);
 
   if (pll_Viewers == NULL)
   {
@@ -787,21 +900,7 @@ gui_mainwindow_load_serie (Tree *pt_Serie)
     /*--------------------------------------------------------------------------.
      | AXIAL VIEWER WIDGET                                                      |
      '--------------------------------------------------------------------------*/
-    Vector3D ts_Pivot;
-    Vector3D ts_Normal;
-    Vector3D ts_Up;
-
-    ts_Pivot = memory_serie_GetPivotpoint(serie);
-
-    ts_Normal.x = 0;
-    ts_Normal.y = 0;
-    ts_Normal.z = -1;
-
-    ts_Up.x = 0;
-    ts_Up.y = 1;
-    ts_Up.z = 0;
-
-    viewer = viewer_new (serie, ts_ActiveMask, NULL, ts_Normal, ts_Pivot, ts_Up);
+    viewer = viewer_new (ps_Serie, ts_ActiveMask, NULL, ts_Normal_Axial, ts_Pivot, ts_Up_Axial);
     if (viewer != NULL)
     {
       viewer_set_orientation (viewer, ORIENTATION_AXIAL);
@@ -812,6 +911,8 @@ gui_mainwindow_load_serie (Tree *pt_Serie)
       viewer_set_callback (viewer, "window-level-change", &gui_mainwindow_update_viewer_wwwl);
       viewer_set_callback (viewer, "handle-change", &gui_mainwindow_update_handle_position);
 
+      v_viewer_set_image_orientation_direction(viewer, pc_Axial_Top, pc_Axial_Bottom, pc_Axial_Left, pc_Axial_Right);
+
       if (ts_ActiveDrawTool != NULL)
         viewer_set_active_painter (viewer, ts_ActiveDrawTool);
 
@@ -821,16 +922,7 @@ gui_mainwindow_load_serie (Tree *pt_Serie)
     /*--------------------------------------------------------------------------.
      | SAGITAL VIEWER WIDGET                                                    |
      '--------------------------------------------------------------------------*/
-
-    ts_Normal.x = 1;
-    ts_Normal.y = 0;
-    ts_Normal.z = 0;
-
-    ts_Up.x = 0;
-    ts_Up.y = 0;
-    ts_Up.z = 1;
-
-    viewer = viewer_new (serie, ts_ActiveMask, NULL, ts_Normal, ts_Pivot, ts_Up);
+    viewer = viewer_new (ps_Serie, ts_ActiveMask, NULL, ts_Normal_Sagital, ts_Pivot, ts_Up_Sagital);
     if (viewer != NULL)
     {
       viewer_set_orientation (viewer, ORIENTATION_SAGITAL);
@@ -841,6 +933,8 @@ gui_mainwindow_load_serie (Tree *pt_Serie)
       viewer_set_callback (viewer, "window-level-change", &gui_mainwindow_update_viewer_wwwl);
       viewer_set_callback (viewer, "handle-change", &gui_mainwindow_update_handle_position);
 
+      v_viewer_set_image_orientation_direction(viewer, pc_Sagital_Top, pc_Sagital_Bottom, pc_Sagital_Left, pc_Sagital_Right);
+
       if (ts_ActiveDrawTool != NULL)
         viewer_set_active_painter (viewer, ts_ActiveDrawTool);
 
@@ -850,16 +944,7 @@ gui_mainwindow_load_serie (Tree *pt_Serie)
     /*--------------------------------------------------------------------------.
      | CORONAL VIEWER WIDGET                                                    |
      '--------------------------------------------------------------------------*/
-
-    ts_Normal.x = 0;
-    ts_Normal.y = 1;
-    ts_Normal.z = 0;
-
-    ts_Up.x = 0;
-    ts_Up.y = 1;
-    ts_Up.z = 0;
-
-    viewer = viewer_new (serie, ts_ActiveMask, NULL, ts_Normal, ts_Pivot, ts_Up);
+    viewer = viewer_new (ps_Serie, ts_ActiveMask, NULL, ts_Normal_Coronal, ts_Pivot, ts_Up_Coronal);
     if (viewer != NULL)
     {
       viewer_set_orientation (viewer, ORIENTATION_CORONAL);
@@ -869,6 +954,8 @@ gui_mainwindow_load_serie (Tree *pt_Serie)
       viewer_set_callback (viewer, "focus-change", &gui_mainwindow_update_viewer_positions);
       viewer_set_callback (viewer, "window-level-change", &gui_mainwindow_update_viewer_wwwl);
       viewer_set_callback (viewer, "handle-change", &gui_mainwindow_update_handle_position);
+
+      v_viewer_set_image_orientation_direction(viewer, pc_Coronal_Top, pc_Coronal_Bottom, pc_Coronal_Left, pc_Coronal_Right);
 
       if (ts_ActiveDrawTool != NULL)
         viewer_set_active_painter (viewer, ts_ActiveDrawTool);
@@ -900,6 +987,7 @@ gui_mainwindow_load_serie (Tree *pt_Serie)
     {
     case VIEWPORT_TYPE_AXIAL:
       gtk_widget_set_visible (GTK_WIDGET (axial_embed), TRUE);
+
       break;
     case VIEWPORT_TYPE_SAGITAL:
       gtk_widget_set_visible (GTK_WIDGET (sagital_embed), TRUE);
@@ -918,11 +1006,11 @@ gui_mainwindow_load_serie (Tree *pt_Serie)
 
     gui_mainwindow_save_undo_step (hbox_viewers, NULL);
 
-    // Display a slider for time series if applicable.
-    if (serie->num_time_series > 1)
+    // Display a slider for time ps_Series if applicable.
+    if (ps_Serie->num_time_series > 1)
     {
       gtk_scale_clear_marks (GTK_SCALE (timeline));
-      gtk_range_set_range (GTK_RANGE (timeline), 1, serie->num_time_series);
+      gtk_range_set_range (GTK_RANGE (timeline), 1, ps_Serie->num_time_series);
       gtk_range_set_value (GTK_RANGE (timeline), 1);
       gtk_widget_show (timeline);
     }
@@ -935,65 +1023,50 @@ gui_mainwindow_load_serie (Tree *pt_Serie)
     List *viewers = list_nth (pll_Viewers, 1);
     while (viewers != NULL)
     {
-      viewer_set_active_layer_serie (viewers->data, serie);
+      viewer_set_active_layer_serie (viewers->data, ps_Serie);
       viewers = list_next (viewers);
     }
   }
   else
   {
-    Vector3D ts_Pivot;
     Vector3D ts_Normal;
     Vector3D ts_Up;
-
-    ts_Pivot = memory_serie_GetPivotpoint(serie);
 
     List *temp = list_nth (pll_Viewers, 1);
     while (temp != NULL)
     {
       Viewer* list_viewer = temp->data;
 
-
       switch (VIEWER_ORIENTATION (list_viewer))
       {
         case ORIENTATION_AXIAL:
-          ts_Up.x = 0;
-          ts_Up.y = 1;
-          ts_Up.z = 0;
+          ts_Up = ts_Up_Axial;
+          ts_Normal = ts_Normal_Axial;
 
-          ts_Normal.x = 0;
-          ts_Normal.y = 0;
-          ts_Normal.z = -1;
+          v_viewer_set_image_orientation_direction(list_viewer, pc_Axial_Top, pc_Axial_Bottom, pc_Axial_Left, pc_Axial_Right);
           break;
         case ORIENTATION_SAGITAL:
-          ts_Up.x = 0;
-          ts_Up.y = 0;
-          ts_Up.z = 1;
-
-          ts_Normal.x = 1;
-          ts_Normal.y = 0;
-          ts_Normal.z = 0;
+          ts_Up = ts_Up_Sagital;
+          ts_Normal = ts_Normal_Sagital;
+          v_viewer_set_image_orientation_direction(list_viewer, pc_Sagital_Top, pc_Sagital_Bottom, pc_Sagital_Left, pc_Sagital_Right);
           break;
         case ORIENTATION_CORONAL:
-          ts_Up.x = 0;
-          ts_Up.y = 1;
-          ts_Up.z = 0;
-
-          ts_Normal.x = 0;
-          ts_Normal.y = 1;
-          ts_Normal.z = 0;
+          ts_Up = ts_Up_Coronal;
+          ts_Normal = ts_Normal_Coronal;
+          v_viewer_set_image_orientation_direction(list_viewer, pc_Coronal_Top, pc_Coronal_Bottom, pc_Coronal_Left, pc_Coronal_Right);
           break;
         default:
           break;
       }
 
-      viewer_initialize (list_viewer, serie, ts_ActiveMask, NULL, ts_Normal, ts_Pivot, ts_Up);
+
+      viewer_initialize (list_viewer, ps_Serie, ts_ActiveMask, NULL, ts_Normal, ts_Pivot, ts_Up);
 
       viewer_refresh_data (list_viewer);
       viewer_redraw (list_viewer, REDRAW_ALL);
 
       temp = temp->next;
     }
-
   }
 }
 

--- a/source/gui/mainwindow.c
+++ b/source/gui/mainwindow.c
@@ -795,7 +795,7 @@ gui_mainwindow_load_serie (Tree *pt_Serie)
 
     ts_Normal.x = 0;
     ts_Normal.y = 0;
-    ts_Normal.z = 1;
+    ts_Normal.z = -1;
 
     ts_Up.x = 0;
     ts_Up.y = 1;
@@ -962,7 +962,7 @@ gui_mainwindow_load_serie (Tree *pt_Serie)
 
           ts_Normal.x = 0;
           ts_Normal.y = 0;
-          ts_Normal.z = 1;
+          ts_Normal.z = -1;
           break;
         case ORIENTATION_SAGITAL:
           ts_Up.x = 0;


### PR DESCRIPTION
When loading an overlay or a image, which is actually a mask, the window
width and level are calculated. If the mask contains only a value 1, the
ww and level are set to 0. This is incorrect behavour. Therefore it
should be like if the max value is less then 255, the lut choosen should
be the mask lut.

This behavour is implemented.
